### PR TITLE
Allow setting will, allow message to be stored in flash

### DIFF
--- a/PubSubClient/PubSubClient.h
+++ b/PubSubClient/PubSubClient.h
@@ -65,6 +65,7 @@ public:
    boolean publish(char *, char *);
    boolean publish(char *, uint8_t *, unsigned int);
    boolean publish(char *, uint8_t *, unsigned int, boolean);
+   boolean publish_P(char *, uint8_t PROGMEM *, unsigned int, boolean);
    boolean subscribe(char *);
    boolean loop();
    boolean connected();


### PR DESCRIPTION
Allow setting of a will without also providing auth credentials.
Added ::publish_P which accepts the message data from PROGMEM. This allows a sketch to send a large pre-defined message.
