### PR TITLE
Constructor & warning fix

### DIFF
--- a/PubSubClient/PubSubClient.cpp
+++ b/PubSubClient/PubSubClient.cpp
@@ -7,15 +7,12 @@
 #include "PubSubClient.h"
 #include <string.h>
 
-PubSubClient::PubSubClient(Client& client) {
-   this->_client = &client;
-}
-
 PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), Client& client) {
    this->_client = &client;
    this->callback = callback;
    this->ip = ip;
    this->port = port;
+   this->domain = NULL;
 }
 
 PubSubClient::PubSubClient(char* domain, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), Client& client) {

--- a/PubSubClient/PubSubClient.cpp
+++ b/PubSubClient/PubSubClient.cpp
@@ -38,13 +38,13 @@ boolean PubSubClient::connect(char *id, char* willTopic, uint8_t willQos, uint8_
 boolean PubSubClient::connect(char *id, char *user, char *pass, char* willTopic, uint8_t willQos, uint8_t willRetain, char* willMessage) {
    if (!connected()) {
       int result = 0;
-      
+
       if (domain != NULL) {
         result = _client->connect(this->domain, this->port);
       } else {
         result = _client->connect(this->ip, this->port);
       }
-      
+
       if (result) {
          nextMsgId = 1;
          uint8_t d[9] = {0x00,0x06,'M','Q','I','s','d','p',MQTTPROTOCOLVERSION};
@@ -86,11 +86,11 @@ boolean PubSubClient::connect(char *id, char *user, char *pass, char* willTopic,
                length = writeString(pass,buffer,length);
             }
          }
-         
+
          write(MQTTCONNECT,buffer,length-5);
-         
+
          lastInActivity = lastOutActivity = millis();
-         
+
          while (!_client->available()) {
             unsigned long t = millis();
             if (t-lastInActivity > MQTT_KEEPALIVE*1000UL) {
@@ -99,7 +99,7 @@ boolean PubSubClient::connect(char *id, char *user, char *pass, char* willTopic,
             }
          }
          uint16_t len = readPacket();
-         
+
          if (len == 4 && buffer[3] == 0) {
             lastInActivity = millis();
             pingOutstanding = false;
@@ -128,7 +128,7 @@ uint16_t PubSubClient::readPacket() {
       length += (digit & 127) * multiplier;
       multiplier *= 128;
    } while ((digit & 128) != 0);
-   
+
    for (uint16_t i = 0;i<length;i++)
    {
       if (len < MQTT_MAX_PACKET_SIZE) {
@@ -145,20 +145,7 @@ uint16_t PubSubClient::readPacket() {
 boolean PubSubClient::loop() {
    if (connected()) {
       unsigned long t = millis();
-      if ((t - lastInActivity > MQTT_KEEPALIVE*1000UL) || (t - lastOutActivity > MQTT_KEEPALIVE*1000UL)) {
-         if (pingOutstanding) {
-            _client->stop();
-            return false;
-         } else {
-            buffer[0] = MQTTPINGREQ;
-            buffer[1] = 0;
-            _client->write(buffer,2);
-            lastOutActivity = t;
-            lastInActivity = t;
-            pingOutstanding = true;
-         }
-      }
-      if (_client->available()) {
+      while (_client->available()) {
          uint16_t len = readPacket();
          if (len > 0) {
             lastInActivity = t;
@@ -182,6 +169,19 @@ boolean PubSubClient::loop() {
             } else if (type == MQTTPINGRESP) {
                pingOutstanding = false;
             }
+         }
+      }
+      if ((t - lastInActivity > MQTT_KEEPALIVE*1000UL) || (t - lastOutActivity > MQTT_KEEPALIVE*1000UL)) {
+         if (pingOutstanding) {
+            _client->stop();
+            return false;
+         } else {
+            buffer[0] = MQTTPINGREQ;
+            buffer[1] = 0;
+            _client->write(buffer,2);
+            lastOutActivity = t;
+            lastInActivity = t;
+            pingOutstanding = true;
          }
       }
       return true;
@@ -224,13 +224,13 @@ boolean PubSubClient::publish_P(char* topic, uint8_t* payload, unsigned int plen
    uint16_t i;
    uint8_t header;
    unsigned int len;
-   
+
    if (!connected()) {
       return false;
    }
-   
+
    tlen = strlen(topic);
-   
+
    header = MQTTPUBLISH;
    if (retained) {
       header |= 1;
@@ -246,15 +246,15 @@ boolean PubSubClient::publish_P(char* topic, uint8_t* payload, unsigned int plen
       buffer[pos++] = digit;
       llen++;
    } while(len>0);
-   
+
    pos = writeString(topic,buffer,pos);
-   
+
    rc = _client->write(buffer,pos);
-   
+
    for (i=0;i<plength;i++) {
       rc += _client->write((char)pgm_read_byte_near(payload + i));
    }
-   
+
    lastOutActivity = millis();
    return rc == len + 1 + plength;
 }
@@ -281,7 +281,7 @@ boolean PubSubClient::write(uint8_t header, uint8_t* buf, uint16_t length) {
       buf[5-llen+i] = lenBuf[i];
    }
    rc = _client->write(buf+(4-llen),length+1+llen);
-   
+
    lastOutActivity = millis();
    return (rc == 1+llen+length);
 }

--- a/PubSubClient/PubSubClient.cpp
+++ b/PubSubClient/PubSubClient.cpp
@@ -215,13 +215,13 @@ boolean PubSubClient::publish(char* topic, uint8_t* payload, unsigned int plengt
    return false;
 }
 
-boolean PubSubClient::publish_P(char* topic, uint8_t* PROGMEM payload, unsigned int plength, boolean retained) {
+boolean PubSubClient::publish_P(char* topic, uint8_t* payload, unsigned int plength, boolean retained) {
    uint8_t llen = 0;
    uint8_t digit;
-   int rc;
+   uint16_t rc;
    uint16_t tlen;
    int pos = 0;
-   int i;
+   uint16_t i;
    uint8_t header;
    unsigned int len;
    
@@ -249,7 +249,7 @@ boolean PubSubClient::publish_P(char* topic, uint8_t* PROGMEM payload, unsigned 
    
    pos = writeString(topic,buffer,pos);
    
-   rc += _client->write(buffer,pos);
+   rc = _client->write(buffer,pos);
    
    for (i=0;i<plength;i++) {
       rc += _client->write((char)pgm_read_byte_near(payload + i));

--- a/PubSubClient/PubSubClient.h
+++ b/PubSubClient/PubSubClient.h
@@ -64,7 +64,7 @@ public:
    boolean publish(char *, char *);
    boolean publish(char *, uint8_t *, unsigned int);
    boolean publish(char *, uint8_t *, unsigned int, boolean);
-   boolean publish_P(char *, uint8_t PROGMEM *, unsigned int, boolean);
+   boolean publish_P(char *, uint8_t *, unsigned int, boolean);
    boolean subscribe(char *);
    boolean loop();
    boolean connected();

--- a/PubSubClient/PubSubClient.h
+++ b/PubSubClient/PubSubClient.h
@@ -14,7 +14,7 @@
 #define MQTT_MAX_PACKET_SIZE 128
 
 // MQTT_KEEPALIVE : keepAlive interval in Seconds
-#define MQTT_KEEPALIVE 15
+#define MQTT_KEEPALIVE 300
 
 #define MQTTPROTOCOLVERSION 3
 #define MQTTCONNECT     1 << 4  // Client request to connect to Server

--- a/PubSubClient/PubSubClient.h
+++ b/PubSubClient/PubSubClient.h
@@ -54,7 +54,6 @@ private:
    char* domain;
    uint16_t port;
 public:
-   PubSubClient(Client& client);
    PubSubClient(uint8_t *, uint16_t, void(*)(char*,uint8_t*,unsigned int),Client& client);
    PubSubClient(char*, uint16_t, void(*)(char*,uint8_t*,unsigned int),Client& client);
    boolean connect(char *);


### PR DESCRIPTION
I'm working on GPS/GPRS tracking system based on Arduino, and your MQTT library is really helpful, thanks. Here's some fix I caught on the way:

* Domain is not initilized in constructor.  This will cause problem when creating PubSubClient at runtime using new. connect() wrongly detect my IP server as domain name.
* On arduino 1.0.2, publish_P() generate warnings from compiler about unused attribute, and signed & unsigned type mismatch
* PubSubClient(Client& client); doesn't seems to be useful? Because you can't set other mandatory parameters after construction (no setters, private fields).