### PR TITLE
Process incoming packet first in loop()

### DIFF
--- a/PubSubClient/PubSubClient.cpp
+++ b/PubSubClient/PubSubClient.cpp
@@ -148,20 +148,7 @@ uint16_t PubSubClient::readPacket() {
 boolean PubSubClient::loop() {
    if (connected()) {
       unsigned long t = millis();
-      if ((t - lastInActivity > MQTT_KEEPALIVE*1000UL) || (t - lastOutActivity > MQTT_KEEPALIVE*1000UL)) {
-         if (pingOutstanding) {
-            _client->stop();
-            return false;
-         } else {
-            buffer[0] = MQTTPINGREQ;
-            buffer[1] = 0;
-            _client->write(buffer,2);
-            lastOutActivity = t;
-            lastInActivity = t;
-            pingOutstanding = true;
-         }
-      }
-      if (_client->available()) {
+      while (_client->available()) {
          uint16_t len = readPacket();
          if (len > 0) {
             lastInActivity = t;
@@ -185,6 +172,19 @@ boolean PubSubClient::loop() {
             } else if (type == MQTTPINGRESP) {
                pingOutstanding = false;
             }
+         }
+      }
+      if ((t - lastInActivity > MQTT_KEEPALIVE*1000UL) || (t - lastOutActivity > MQTT_KEEPALIVE*1000UL)) {
+         if (pingOutstanding) {
+            _client->stop();
+            return false;
+         } else {
+            buffer[0] = MQTTPINGREQ;
+            buffer[1] = 0;
+            _client->write(buffer,2);
+            lastOutActivity = t;
+            lastInActivity = t;
+            pingOutstanding = true;
          }
       }
       return true;


### PR DESCRIPTION
Hi Nick,

I'm writing a GPRSClient. I've got a case where I can only call PubSubClient::loop() after a long operation (GPRSClient::write() with timeout of 30 seconds, way beyond MQTT_KEEPALIVE). On that period a MQTT packet came (PingResp in this case). When I finally call PubSubClient::loop() it disconnect the connection because of PingOutstanding timeout, even though the packet is there in GPRSClient RX buffer. This patch fix that problem by handling incoming packet first before checking for timeout.

Regards,
Anugrah
