### PR TITLE
Fixing bug for large message packets

### DIFF
--- a/PubSubClient/PubSubClient.cpp
+++ b/PubSubClient/PubSubClient.cpp
@@ -124,7 +124,7 @@ uint8_t PubSubClient::readByte() {
 uint16_t PubSubClient::readPacket(uint8_t* lengthLength) {
    uint16_t len = 0;
    buffer[len++] = readByte();
-   uint8_t multiplier = 1;
+   uint32_t multiplier = 1;
    uint16_t length = 0;
    uint8_t digit = 0;
    do {


### PR DESCRIPTION
The protocol uses up to four bytes for message size. As the multiplier is uint8_t this will only handle up to 2 bytes (128*128) before it hits the ceiling. uint32_t means we can handle max size messages.
