### PR TITLE
support for streaming send

### DIFF
--- a/PubSubClient/PubSubClient.h
+++ b/PubSubClient/PubSubClient.h
@@ -50,6 +50,7 @@ private:
    uint16_t readPacket(uint8_t*);
    uint8_t readByte();
    boolean write(uint8_t header, uint8_t* buf, uint16_t length);
+   boolean write(uint8_t header, uint8_t* buf, uint16_t length, bool sendData);
    uint16_t writeString(char* string, uint8_t* buf, uint16_t pos);
    uint8_t *ip;
    char* domain;
@@ -69,6 +70,7 @@ public:
    boolean publish(char *, char *);
    boolean publish(char *, uint8_t *, unsigned int);
    boolean publish(char *, uint8_t *, unsigned int, boolean);
+   boolean publishHeader(char* topic, unsigned int plength, boolean retained);
    boolean publish_P(char *, uint8_t PROGMEM *, unsigned int, boolean);
    boolean subscribe(char *);
    boolean subscribe(char *, uint8_t qos);


### PR DESCRIPTION
These additions allow you to remove large buffer from your send code. In our implementation we b64 the data we're going to send, but want to do that on the fly to keep away from yet another buffer. Now we can calculate the amount of characters we intend to send, have pubsubclient send the appropriate header and allow us to finish up!

``` cpp
//max 51 was arbitrary to come under the wifi shield limit
int len = b64::encodeLength(stream.available() > 51 ? 51 : stream.available());

mqtt.publishHeader("topic", len, false);

//encode from our stream object directly into the client
b64::encode(stream, client, len);
```
