### PR TITLE
Intel Galileo and Edison Support

### DIFF
--- a/PubSubClient/PubSubClient.h
+++ b/PubSubClient/PubSubClient.h
@@ -10,6 +10,8 @@
 #include <Arduino.h>
 #include "Client.h"
 #include "Stream.h"
+//Adding support for Intel Galileo with Intel arduino SDK and Intel Edison arduino SDK
+#include <avr/pgmspace.h>
 
 // MQTT_MAX_PACKET_SIZE : Maximum packet size
 #define MQTT_MAX_PACKET_SIZE 128


### PR DESCRIPTION
added #include <avr/pgmspace.h> and this library is now compatible with Intel Galileo and Intel Edison boards