### PR TITLE
refactored constructors to use getters and setters

### DIFF
--- a/PubSubClient/PubSubClient.cpp
+++ b/PubSubClient/PubSubClient.cpp
@@ -8,42 +8,46 @@
 #include <string.h>
 
 PubSubClient::PubSubClient() {
-   this->_client = NULL;
-   this->stream = NULL;
+   this->_client = 0;
+   setCallback(NULL);
+   setBrokerIP(ip);
+   setPort(1883);
+   setBrokerDomain(NULL);
+   this->stream = 0;
 }
 
 PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), Client& client) {
-   this->_client = &client;
-   this->callback = callback;
-   this->ip = ip;
-   this->port = port;
-   this->domain = NULL;
-   this->stream = NULL;
+   setClient(client);
+   setCallback(callback);
+   setBrokerIP(ip);
+   setPort(port);
+   setBrokerDomain(NULL);
+   this->stream = 0;
 }
 
 PubSubClient::PubSubClient(char* domain, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), Client& client) {
-   this->_client = &client;
-   this->callback = callback;
-   this->domain = domain;
-   this->port = port;
-   this->stream = NULL;
+   setClient(client);
+   setCallback(callback);
+   setBrokerDomain(domain);
+   setPort(port);
+   this->stream = 0;
 }
 
 PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), Client& client, Stream& stream) {
-   this->_client = &client;
-   this->callback = callback;
-   this->ip = ip;
-   this->port = port;
-   this->domain = NULL;
-   this->stream = &stream;
+   setClient(client);  
+   setCallback(callback);
+   setBrokerIP(ip);
+   setPort(port);
+   setBrokerDomain(NULL);
+   setStream(stream);
 }
 
 PubSubClient::PubSubClient(char* domain, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), Client& client, Stream& stream) {
-   this->_client = &client;
-   this->callback = callback;
-   this->domain = domain;
-   this->port = port;
-   this->stream = &stream;
+   setClient(client);
+   setCallback(callback);
+   setBrokerDomain(domain);
+   setPort(port);
+   setStream(stream);
 }
 
 boolean PubSubClient::connect(char *id) {
@@ -425,3 +429,27 @@ boolean PubSubClient::connected() {
    return rc;
 }
 
+void PubSubClient::setBrokerIP(uint8_t * ip){
+  this->domain = NULL;
+  this->ip = ip;
+}
+
+void PubSubClient::setBrokerDomain(char * domain){
+  this->domain = domain;
+}
+
+void PubSubClient::setCallback(void(*callback)(char*,uint8_t*,unsigned int)){
+  this->callback = callback;
+}
+
+void PubSubClient::setPort(uint16_t port){
+  this->port = port;
+}
+
+void PubSubClient::setClient(Client& client){
+  this->_client = &client;
+}
+
+void PubSubClient::setStream(Stream& stream){
+  this->stream = &stream;
+}

--- a/PubSubClient/PubSubClient.cpp
+++ b/PubSubClient/PubSubClient.cpp
@@ -8,12 +8,11 @@
 #include <string.h>
 
 PubSubClient::PubSubClient() {
-   this->_client = 0;
+   this->_client = NULL;
+   this->stream = NULL;   
    setCallback(NULL);
-   setBrokerIP(ip);
    setPort(1883);
    setBrokerDomain(NULL);
-   this->stream = 0;
 }
 
 PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), Client& client) {
@@ -22,7 +21,7 @@ PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, void (*callback)(char*,ui
    setBrokerIP(ip);
    setPort(port);
    setBrokerDomain(NULL);
-   this->stream = 0;
+   this->stream = NULL;
 }
 
 PubSubClient::PubSubClient(char* domain, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), Client& client) {
@@ -30,7 +29,7 @@ PubSubClient::PubSubClient(char* domain, uint16_t port, void (*callback)(char*,u
    setCallback(callback);
    setBrokerDomain(domain);
    setPort(port);
-   this->stream = 0;
+   this->stream = NULL;
 }
 
 PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), Client& client, Stream& stream) {

--- a/PubSubClient/PubSubClient.h
+++ b/PubSubClient/PubSubClient.h
@@ -61,6 +61,14 @@ public:
    PubSubClient(uint8_t *, uint16_t, void(*)(char*,uint8_t*,unsigned int),Client& client, Stream&);
    PubSubClient(char*, uint16_t, void(*)(char*,uint8_t*,unsigned int),Client& client);
    PubSubClient(char*, uint16_t, void(*)(char*,uint8_t*,unsigned int),Client& client, Stream&);
+   
+   void setBrokerIP(uint8_t * ip);
+   void setBrokerDomain(char * domain);   
+   void setCallback(void(*callback)(char*,uint8_t*,unsigned int));
+   void setPort(uint16_t port);
+   void setClient(Client& client);
+   void setStream(Stream& stream);
+   
    boolean connect(char *);
    boolean connect(char *, char *, char *);
    boolean connect(char *, char *, uint8_t, uint8_t, char *);


### PR DESCRIPTION
I believe this addresses Issue #58 (at least). I implemented some setters that allow for dynamic runtime configuration of the PubSubClient. The most likely use case I can think of is using the empty constructor to create a global instance, then in setup() assigning the various fields based on configuration. I also don't believe this pull request alters the existing examples and usage patterns.