### PR TITLE
Made Library compile on ESP8266-Modules.

### DIFF
--- a/PubSubClient/PubSubClient.cpp
+++ b/PubSubClient/PubSubClient.cpp
@@ -281,6 +281,9 @@ boolean PubSubClient::publish(char* topic, uint8_t* payload, unsigned int plengt
    return false;
 }
 
+// Dont provide this method if on an ESP8266-Chip as it doesn't have PROGMEM
+#ifdef ESP8266
+#else
 boolean PubSubClient::publish_P(char* topic, uint8_t* PROGMEM payload, unsigned int plength, boolean retained) {
    uint8_t llen = 0;
    uint8_t digit;
@@ -325,6 +328,7 @@ boolean PubSubClient::publish_P(char* topic, uint8_t* PROGMEM payload, unsigned 
    
    return rc == tlen + 4 + plength;
 }
+#endif
 
 boolean PubSubClient::write(uint8_t header, uint8_t* buf, uint16_t length) {
    uint8_t lenBuf[4];

--- a/PubSubClient/PubSubClient.h
+++ b/PubSubClient/PubSubClient.h
@@ -69,7 +69,10 @@ public:
    boolean publish(char *, char *);
    boolean publish(char *, uint8_t *, unsigned int);
    boolean publish(char *, uint8_t *, unsigned int, boolean);
+#ifdef ESP8266
+#else
    boolean publish_P(char *, uint8_t PROGMEM *, unsigned int, boolean);
+#endif
    boolean subscribe(char *);
    boolean subscribe(char *, uint8_t qos);
    boolean unsubscribe(char *);


### PR DESCRIPTION
On an ESP8266-Chip, the *PROGMEM*-based publish-method doesn't get compiled, as it can't be used anyways.