### PR TITLE
Changed "or" to "and" to fix issue with publishing only implementations.

### DIFF
--- a/PubSubClient/src/PubSubClient.cpp
+++ b/PubSubClient/src/PubSubClient.cpp
@@ -263,7 +263,7 @@ uint16_t PubSubClient::readPacket(uint8_t* lengthLength) {
 boolean PubSubClient::loop() {
     if (connected()) {
         unsigned long t = millis();
-        if ((t - lastInActivity > MQTT_KEEPALIVE*1000UL) || (t - lastOutActivity > MQTT_KEEPALIVE*1000UL)) {
+        if ((t - lastInActivity > MQTT_KEEPALIVE*1000UL) && (t - lastOutActivity > MQTT_KEEPALIVE*1000UL)) {
             if (pingOutstanding) {
                 this->_state = MQTT_CONNECTION_TIMEOUT;
                 _client->stop();


### PR DESCRIPTION
When testing this with a device that only publishes, the connection eventually times out and then needs to be re-established for EVERY message published. 
Changing this fixes the problem, and does not appear to affect the normal operation.