### PR TITLE
only define max msg len if not defined yet

### DIFF
--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -20,7 +20,9 @@
 #define MQTT_VERSION MQTT_VERSION_3_1_1
 
 // MQTT_MAX_PACKET_SIZE : Maximum packet size
+#ifndef MQTT_MAX_PACKET_SIZE
 #define MQTT_MAX_PACKET_SIZE 128
+#endif
 
 // MQTT_KEEPALIVE : keepAlive interval in Seconds
 #define MQTT_KEEPALIVE 15


### PR DESCRIPTION
Allows this setting to be redefined without modifying the pubsubclient.h file.