### PR TITLE
Match the length of type for writing data

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -428,7 +428,7 @@ boolean PubSubClient::write(uint8_t header, uint8_t* buf, uint16_t length) {
 
 #ifdef MQTT_MAX_TRANSFER_SIZE
     uint8_t* writeBuf = buf+(4-llen);
-    uint8_t bytesRemaining = length+1+llen;
+    uint16_t bytesRemaining = length+1+llen;  //Match the length type
     uint8_t bytesToWrite;
     boolean result = true;
     while((bytesRemaining > 0) && result) {


### PR DESCRIPTION
In MQTT_MAX_TRANSFER_SIZE case, the variable bytesRemaining needs to match the type of data length. In my case, the length is over 256. The length would be overflow.