### PR TITLE
Implement timeout behavior in readByte / readPacket

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -12,14 +12,12 @@ PubSubClient::PubSubClient() {
     this->_client = NULL;
     this->stream = NULL;
     setCallback(NULL);
-    setReadTimeout(-1);
 }
 
 PubSubClient::PubSubClient(Client& client) {
     this->_state = MQTT_DISCONNECTED;
     setClient(client);
     this->stream = NULL;
-    setReadTimeout(-1);
 }
 
 PubSubClient::PubSubClient(IPAddress addr, uint16_t port, Client& client) {
@@ -27,14 +25,12 @@ PubSubClient::PubSubClient(IPAddress addr, uint16_t port, Client& client) {
     setServer(addr, port);
     setClient(client);
     this->stream = NULL;
-    setReadTimeout(-1);
 }
 PubSubClient::PubSubClient(IPAddress addr, uint16_t port, Client& client, Stream& stream) {
     this->_state = MQTT_DISCONNECTED;
     setServer(addr,port);
     setClient(client);
     setStream(stream);
-    setReadTimeout(-1);
 }
 PubSubClient::PubSubClient(IPAddress addr, uint16_t port, MQTT_CALLBACK_SIGNATURE, Client& client) {
     this->_state = MQTT_DISCONNECTED;
@@ -42,7 +38,6 @@ PubSubClient::PubSubClient(IPAddress addr, uint16_t port, MQTT_CALLBACK_SIGNATUR
     setCallback(callback);
     setClient(client);
     this->stream = NULL;
-    setReadTimeout(-1);
 }
 PubSubClient::PubSubClient(IPAddress addr, uint16_t port, MQTT_CALLBACK_SIGNATURE, Client& client, Stream& stream) {
     this->_state = MQTT_DISCONNECTED;
@@ -50,7 +45,6 @@ PubSubClient::PubSubClient(IPAddress addr, uint16_t port, MQTT_CALLBACK_SIGNATUR
     setCallback(callback);
     setClient(client);
     setStream(stream);
-    setReadTimeout(-1);
 }
 
 PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, Client& client) {
@@ -58,14 +52,12 @@ PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, Client& client) {
     setServer(ip, port);
     setClient(client);
     this->stream = NULL;
-    setReadTimeout(-1);
 }
 PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, Client& client, Stream& stream) {
     this->_state = MQTT_DISCONNECTED;
     setServer(ip,port);
     setClient(client);
     setStream(stream);
-    setReadTimeout(-1);
 }
 PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, MQTT_CALLBACK_SIGNATURE, Client& client) {
     this->_state = MQTT_DISCONNECTED;
@@ -73,7 +65,6 @@ PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, MQTT_CALLBACK_SIGNATURE, 
     setCallback(callback);
     setClient(client);
     this->stream = NULL;
-    setReadTimeout(-1);
 }
 PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, MQTT_CALLBACK_SIGNATURE, Client& client, Stream& stream) {
     this->_state = MQTT_DISCONNECTED;
@@ -81,7 +72,6 @@ PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, MQTT_CALLBACK_SIGNATURE, 
     setCallback(callback);
     setClient(client);
     setStream(stream);
-    setReadTimeout(-1);
 }
 
 PubSubClient::PubSubClient(const char* domain, uint16_t port, Client& client) {
@@ -89,14 +79,12 @@ PubSubClient::PubSubClient(const char* domain, uint16_t port, Client& client) {
     setServer(domain,port);
     setClient(client);
     this->stream = NULL;
-    setReadTimeout(-1);
 }
 PubSubClient::PubSubClient(const char* domain, uint16_t port, Client& client, Stream& stream) {
     this->_state = MQTT_DISCONNECTED;
     setServer(domain,port);
     setClient(client);
     setStream(stream);
-    setReadTimeout(-1);
 }
 PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGNATURE, Client& client) {
     this->_state = MQTT_DISCONNECTED;
@@ -104,7 +92,6 @@ PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGN
     setCallback(callback);
     setClient(client);
     this->stream = NULL;
-    setReadTimeout(-1);
 }
 PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGNATURE, Client& client, Stream& stream) {
     this->_state = MQTT_DISCONNECTED;
@@ -112,7 +99,6 @@ PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGN
     setCallback(callback);
     setClient(client);
     setStream(stream);
-    setReadTimeout(-1);
 }
 
 boolean PubSubClient::connect(const char *id) {
@@ -191,7 +177,7 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
 
             while (!_client->available()) {
                 unsigned long t = millis();
-                if (t-lastInActivity > MQTT_KEEPALIVE*1000UL) {
+                if (t-lastInActivity >= ((int32_t) MQTT_SOCKET_TIMEOUT*1000UL)) {
                     _state = MQTT_CONNECTION_TIMEOUT;
                     _client->stop();
                     return false;
@@ -224,10 +210,8 @@ boolean PubSubClient::readByte(uint8_t * result) {
    uint32_t previousMillis = millis();
    while(!_client->available()) {
      uint32_t currentMillis = millis();     
-     if(read_timeout_ms > 0){
-       if(currentMillis - previousMillis >= read_timeout_ms){
-         return false;
-       }
+     if(currentMillis - previousMillis >= ((int32_t) MQTT_SOCKET_TIMEOUT * 1000)){
+       return false;
      }
    }
    *result = _client->read();
@@ -599,10 +583,6 @@ PubSubClient& PubSubClient::setClient(Client& client){
 PubSubClient& PubSubClient::setStream(Stream& stream){
     this->stream = &stream;
     return *this;
-}
-
-void PubSubClient::setReadTimeout(int32_t timeout_ms){
-  read_timeout_ms = timeout_ms;
 }
 
 int PubSubClient::state() {

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -221,7 +221,6 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
 
 // reads a byte into result
 boolean PubSubClient::readByte(uint8_t * result) {
-   boolean ret = false;
    uint32_t previousMillis = millis();
    while(!_client->available()) {
      uint32_t currentMillis = millis();     
@@ -237,14 +236,13 @@ boolean PubSubClient::readByte(uint8_t * result) {
 
 // reads a byte into result[*index] and increments index
 boolean PubSubClient::readByte(uint8_t * result, uint16_t * index){
-  boolean ret = false;
   uint16_t current_index = *index;
   uint8_t * write_address = &(result[current_index]);
   if(readByte(write_address)){
     *index = current_index + 1;
-    ret = true;
+    return true;
   }
-  return ret;
+  return false;
 }
 
 uint16_t PubSubClient::readPacket(uint8_t* lengthLength) {

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -74,7 +74,8 @@ private:
    bool pingOutstanding;
    MQTT_CALLBACK_SIGNATURE;
    uint16_t readPacket(uint8_t*);
-   uint8_t readByte();
+   boolean readByte(uint8_t * result);
+   boolean readByte(uint8_t * result, uint16_t * index);
    boolean write(uint8_t header, uint8_t* buf, uint16_t length);
    uint16_t writeString(const char* string, uint8_t* buf, uint16_t pos);
    IPAddress ip;
@@ -82,6 +83,7 @@ private:
    uint16_t port;
    Stream* stream;
    int _state;
+   int32_t read_timeout_ms;
 public:
    PubSubClient();
    PubSubClient(Client& client);
@@ -104,6 +106,7 @@ public:
    PubSubClient& setCallback(MQTT_CALLBACK_SIGNATURE);
    PubSubClient& setClient(Client& client);
    PubSubClient& setStream(Stream& stream);
+   void setReadTimeout(int32_t timeout_ms);
 
    boolean connect(const char* id);
    boolean connect(const char* id, const char* user, const char* pass);

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -25,6 +25,9 @@
 // MQTT_KEEPALIVE : keepAlive interval in Seconds
 #define MQTT_KEEPALIVE 15
 
+// MQTT_SOCKET_TIMEOUT: socket timeout interval in Seconds
+#define MQTT_SOCKET_TIMEOUT 15
+
 // MQTT_MAX_TRANSFER_SIZE : limit how much data is passed to the network client
 //  in each write call. Needed for the Arduino Wifi Shield. Leave undefined to
 //  pass the entire MQTT packet in each write call.
@@ -83,7 +86,6 @@ private:
    uint16_t port;
    Stream* stream;
    int _state;
-   int32_t read_timeout_ms;
 public:
    PubSubClient();
    PubSubClient(Client& client);
@@ -106,7 +108,6 @@ public:
    PubSubClient& setCallback(MQTT_CALLBACK_SIGNATURE);
    PubSubClient& setClient(Client& client);
    PubSubClient& setStream(Stream& stream);
-   void setReadTimeout(int32_t timeout_ms);
 
    boolean connect(const char* id);
    boolean connect(const char* id, const char* user, const char* pass);


### PR DESCRIPTION
This PR addresses issue #87, ran overnight publishing a messages at about 1Hz. Still running without issue this morning after > 50000 messages published and > 18 hours of runtime. I think it's ready to merge.