### PR TITLE
publish qos 0,1,2; loop() before publish and subscribes; others

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,14 @@ Full API documentation is available here: http://pubsubclient.knolleary.net
 
 ## Limitations
 
- - It can only publish QoS 0 messages. It can subscribe at QoS 0 or QoS 1.
+ - It can subscribe at QoS 0 or 1.
+ - It can publish at QoS 0, 1 or 2. WARNING! No retransmission is supported to
+   keep the library as much memory friendly as possible. (Without retransmission
+   support, the publish QoS is only meaningful when the broker sends your
+   message to a subscriber, supposing that the subscriber subscribes with a QoS
+   greater then or equal to the publish QoS; consider that MQTT runs over TCP,
+   so retransmission isn't really required in most cases, especially when
+   publishing to the broker)
  - The maximum message size, including header, is **128 bytes** by default. This
    is configurable via `MQTT_MAX_PACKET_SIZE` in `PubSubClient.h`.
  - The keepalive interval is set to 15 seconds by default. This is configurable

--- a/examples/mqtt_esp8266/mqtt_esp8266.ino
+++ b/examples/mqtt_esp8266/mqtt_esp8266.ino
@@ -11,9 +11,7 @@
   - If the first character of the topic "inTopic" is an 1, switch ON the ESP Led,
     else switch it off
 
- It will reconnect to the server if the connection is lost using a blocking
- reconnect function. See the 'mqtt_reconnect_nonblocking' example for how to
- achieve the same result without blocking the main loop.
+ It will reconnect to the server if the connection is lost
 
  To install the ESP8266 board, (using Arduino 1.6.4+):
   - Add the following 3rd party board manager under "File -> Preferences -> Additional Boards Manager URLs":
@@ -30,20 +28,66 @@
 
 const char* ssid = "........";
 const char* password = "........";
-const char* mqtt_server = "broker.mqtt-dashboard.com";
 
-WiFiClient espClient;
-PubSubClient client(espClient);
+#define MQTTid              "mydevice"                   //id of this mqtt client
+#define MQTTip              "broker.mqtt-dashboard.com"  //ip address or hostname of the mqtt broker
+#define MQTTport            1883                         //port of the mqtt broker
+#define MQTTuser            "user"                       //username of this mqtt client
+#define MQTTpsw             "password"                   //password of this mqtt client
+#define MQTTpubQos          2                            //qos of publish (see README)
+#define MQTTsubQos          1                            //qos of subscribe
+
 long lastMsg = 0;
 char msg[50];
 int value = 0;
 
-void setup() {
-  pinMode(BUILTIN_LED, OUTPUT);     // Initialize the BUILTIN_LED pin as an output
-  Serial.begin(115200);
-  setup_wifi();
-  client.setServer(mqtt_server, 1883);
-  client.setCallback(callback);
+boolean pendingDisconnect = false;
+void mqttConnectedCb(); // on connect callback
+void mqttDisconnectedCb(); // on disconnect callback
+void mqttDataCb(char* topic, byte* payload, unsigned int length); // on new message callback
+
+WiFiClient wclient;
+PubSubClient client(MQTTip, MQTTport, mqttDataCb, wclient);
+
+void mqttConnectedCb() {
+  Serial.println("connected");
+	
+  // Once connected, publish an announcement...
+  client.publish("outTopic", "hello world", MQTTpubQos, true); // true means retain
+  // ... and resubscribe
+  client.subscribe("inTopic", MQTTsubQos);
+
+}
+
+void mqttDisconnectedCb() {
+  Serial.println("disconnected");
+}
+
+void mqttDataCb(char* topic, byte* payload, unsigned int length) {
+
+  /*
+  you can convert payload to a C string appending a null terminator to it;
+  this is possible when the message (including protocol overhead) doesn't
+  exceeds the MQTT_MAX_PACKET_SIZE defined in the library header.
+  you can consider safe to do so when the length of topic plus the length of
+  message doesn't exceeds 115 characters
+  */
+  char* message = (char *) payload;
+  message[length] = 0;
+
+  Serial.print("Message arrived [");
+  Serial.print(topic);
+  Serial.print("] ");
+  Serial.println(message);
+
+  // Switch on the LED if an 1 was received as first character
+  if (message[0] == '1') {
+    digitalWrite(BUILTIN_LED, LOW);   // Turn the LED on (Note that LOW is the voltage level
+    // but actually the LED is on; this is because
+    // it is acive low on the ESP-01)
+  } else {
+    digitalWrite(BUILTIN_LED, HIGH);  // Turn the LED off by making the voltage HIGH
+  }
 }
 
 void setup_wifi() {
@@ -67,60 +111,47 @@ void setup_wifi() {
   Serial.println(WiFi.localIP());
 }
 
-void callback(char* topic, byte* payload, unsigned int length) {
-  Serial.print("Message arrived [");
-  Serial.print(topic);
-  Serial.print("] ");
-  for (int i = 0; i < length; i++) {
-    Serial.print((char)payload[i]);
-  }
-  Serial.println();
-
-  // Switch on the LED if an 1 was received as first character
-  if ((char)payload[0] == '1') {
-    digitalWrite(BUILTIN_LED, LOW);   // Turn the LED on (Note that LOW is the voltage level
-    // but actually the LED is on; this is because
-    // it is acive low on the ESP-01)
-  } else {
-    digitalWrite(BUILTIN_LED, HIGH);  // Turn the LED off by making the voltage HIGH
-  }
-
+void setup() {
+  pinMode(BUILTIN_LED, OUTPUT);     // Initialize the BUILTIN_LED pin as an output
+  Serial.begin(115200);
+  setup_wifi();
 }
 
-void reconnect() {
-  // Loop until we're reconnected
-  while (!client.connected()) {
-    Serial.print("Attempting MQTT connection...");
-    // Attempt to connect
-    if (client.connect("ESP8266Client")) {
-      Serial.println("connected");
-      // Once connected, publish an announcement...
-      client.publish("outTopic", "hello world");
-      // ... and resubscribe
-      client.subscribe("inTopic");
+void process_mqtt() {
+  if (WiFi.status() == WL_CONNECTED) {
+    if (client.connected()) {
+      client.loop();
     } else {
-      Serial.print("failed, rc=");
-      Serial.print(client.state());
-      Serial.println(" try again in 5 seconds");
-      // Wait 5 seconds before retrying
-      delay(5000);
+	  // client id, client username, client password, last will topic, last will qos, last will retain, last will message
+      if (client.connect(MQTTid, MQTTuser, MQTTpsw, MQTTid "/status", 2, true, "0")) {
+          pendingDisconnect = false;
+          mqttConnectedCb();
+      }
     }
+  } else {
+    if (client.connected())
+      client.disconnect();
+  }
+  if (!client.connected() && !pendingDisconnect) {
+    pendingDisconnect = true;
+    mqttDisconnectedCb();
   }
 }
+
 void loop() {
 
-  if (!client.connected()) {
-    reconnect();
-  }
-  client.loop();
+  process_mqtt();
 
   long now = millis();
   if (now - lastMsg > 2000) {
     lastMsg = now;
     ++value;
     snprintf (msg, 75, "hello world #%ld", value);
-    Serial.print("Publish message: ");
-    Serial.println(msg);
-    client.publish("outTopic", msg);
+	
+    if (client.connected()) {
+        Serial.print("Publish message: ");
+        Serial.println(msg);
+        client.publish("outTopic", msg);
+    }
   }
 }

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -122,7 +122,7 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
         } else {
             result = _client->connect(this->ip, this->port);
         }
-        if (result) {
+        if (result > 0) {
             nextMsgId = 1;
             // Leave room in the buffer for header and variable length field
             uint16_t length = 5;

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -229,16 +229,29 @@ boolean PubSubClient::readByte(uint8_t * result, uint16_t * index){
   return false;
 }
 
+// reads an entire MQTT packet;
+// put "remaining length" (see MQTT spec) in lengthLength;
+// return packet size;
 uint16_t PubSubClient::readPacket(uint8_t* lengthLength) {
+	/* PACKET STRUCTURE:
+	1 byte: fixed header
+	lengthLength bytes: remaining length (variable header size + payload size)
+	2 bytes: topic length (if MQTTPUBLISH)
+	n bytes: topic (if MQTTPUBLISH)
+	2 bytes: message id (if qos>0)
+	p byte; payload
+	*/
+	
     uint16_t len = 0;
     if(!readByte(buffer, &len)) return 0;
     bool isPublish = (buffer[0]&0xF0) == MQTTPUBLISH;
     uint32_t multiplier = 1;
-    uint16_t length = 0;
-    uint8_t digit = 0;
-    uint16_t skip = 0;
-    uint8_t start = 0;
+    uint16_t length = 0; // remaining length
+    uint8_t digit = 0; // single byte buffer
+    uint16_t skip = 0; // if MQTTPUBLISH, = topic length + message id length (if qos>0)
+    uint8_t start = 0; // =2 if MQTTPUBLISH, to skip the two already read topic length bytes in the for loop
 
+	// find the reamining leanght (lengthLength)
     do {
         if(!readByte(&digit)) return 0;
         buffer[len++] = digit;
@@ -259,6 +272,7 @@ uint16_t PubSubClient::readPacket(uint8_t* lengthLength) {
         }
     }
 
+	// read variable header and payload
     for (uint16_t i = start;i<length;i++) {
         if(!readByte(&digit)) return 0;
         if (this->stream) {
@@ -277,6 +291,7 @@ uint16_t PubSubClient::readPacket(uint8_t* lengthLength) {
     }
 
     return len;
+	
 }
 
 boolean PubSubClient::loop() {
@@ -296,7 +311,7 @@ boolean PubSubClient::loop() {
                 pingOutstanding = true;
             }
         }
-        if (_client->available()) {
+        while (_client->available()) {
             uint8_t llen;
             uint16_t len = readPacket(&llen);
             uint16_t msgId = 0;
@@ -330,6 +345,9 @@ boolean PubSubClient::loop() {
                             callback(topic,payload,len-llen-3-tl);
                         }
                     }
+                } else if (type == MQTTPUBREC) {
+                    buffer[0] = MQTTPUBREL | 2; // 7th bit of first byte must be set for PUBREL
+                    _client->write(buffer,4); // 2nd, 3rd and 4th bytes of PUBREL are the same of PUBREC
                 } else if (type == MQTTPINGREQ) {
                     buffer[0] = MQTTPINGRESP;
                     buffer[1] = 0;
@@ -345,26 +363,34 @@ boolean PubSubClient::loop() {
 }
 
 boolean PubSubClient::publish(const char* topic, const char* payload) {
-    return publish(topic,(const uint8_t*)payload,strlen(payload),false);
+    return publish(topic,(const uint8_t*)payload,strlen(payload),0,false);
 }
 
-boolean PubSubClient::publish(const char* topic, const char* payload, boolean retained) {
-    return publish(topic,(const uint8_t*)payload,strlen(payload),retained);
+boolean PubSubClient::publish(const char* topic, const char* payload, uint8_t qos, boolean retained) {
+    return publish(topic,(const uint8_t*)payload,strlen(payload),qos,retained);
 }
 
 boolean PubSubClient::publish(const char* topic, const uint8_t* payload, unsigned int plength) {
-    return publish(topic, payload, plength, false);
+    return publish(topic, payload, plength, 0, false);
 }
 
-boolean PubSubClient::publish(const char* topic, const uint8_t* payload, unsigned int plength, boolean retained) {
+boolean PubSubClient::publish(const char* topic, const uint8_t* payload, unsigned int plength, uint8_t qos, boolean retained) {
+	loop();
     if (connected()) {
-        if (MQTT_MAX_PACKET_SIZE < 5 + 2+strlen(topic) + plength) {
+        if (MQTT_MAX_PACKET_SIZE < 5 + 2+strlen(topic) + plength + (qos ? 2 : 0)) {
             // Too long
             return false;
         }
         // Leave room in the buffer for header and variable length field
         uint16_t length = 5;
         length = writeString(topic,buffer,length);
+		if (qos) {
+			nextMsgId++;
+			if (nextMsgId == 0)
+				nextMsgId = 1;
+			buffer[length++] = (nextMsgId >> 8);
+			buffer[length++] = (nextMsgId & 0xFF);
+		}
         uint16_t i;
         for (i=0;i<plength;i++) {
             buffer[length++] = payload[i];
@@ -373,12 +399,17 @@ boolean PubSubClient::publish(const char* topic, const uint8_t* payload, unsigne
         if (retained) {
             header |= 1;
         }
+		header |= qos << 1;
         return write(header,buffer,length-5);
+
     }
     return false;
 }
 
-boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsigned int plength, boolean retained) {
+boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsigned int plength, uint8_t qos, boolean retained) {
+	
+	loop();
+
     uint8_t llen = 0;
     uint8_t digit;
     unsigned int rc = 0;
@@ -398,6 +429,7 @@ boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsig
     if (retained) {
         header |= 1;
     }
+	header |= qos << 1;
     buffer[pos++] = header;
     len = plength + 2 + tlen;
     do {
@@ -419,7 +451,7 @@ boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsig
     }
 
     lastOutActivity = millis();
-
+	
     return rc == tlen + 4 + plength;
 }
 
@@ -470,6 +502,7 @@ boolean PubSubClient::subscribe(const char* topic) {
 }
 
 boolean PubSubClient::subscribe(const char* topic, uint8_t qos) {
+	loop();
     if (qos < 0 || qos > 1) {
         return false;
     }
@@ -488,12 +521,13 @@ boolean PubSubClient::subscribe(const char* topic, uint8_t qos) {
         buffer[length++] = (nextMsgId & 0xFF);
         length = writeString((char*)topic, buffer,length);
         buffer[length++] = qos;
-        return write(MQTTSUBSCRIBE|MQTTQOS1,buffer,length-5);
+		return write(MQTTSUBSCRIBE|MQTTQOS1,buffer,length-5);
     }
     return false;
 }
 
 boolean PubSubClient::unsubscribe(const char* topic) {
+	loop();
     if (MQTT_MAX_PACKET_SIZE < 9 + strlen(topic)) {
         // Too long
         return false;
@@ -507,7 +541,7 @@ boolean PubSubClient::unsubscribe(const char* topic) {
         buffer[length++] = (nextMsgId >> 8);
         buffer[length++] = (nextMsgId & 0xFF);
         length = writeString(topic, buffer,length);
-        return write(MQTTUNSUBSCRIBE|MQTTQOS1,buffer,length-5);
+		return write(MQTTUNSUBSCRIBE|MQTTQOS1,buffer,length-5);
     }
     return false;
 }

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -23,7 +23,7 @@
 #define MQTT_MAX_PACKET_SIZE 128
 
 // MQTT_KEEPALIVE : keepAlive interval in Seconds
-#define MQTT_KEEPALIVE 15
+#define MQTT_KEEPALIVE 30
 
 // MQTT_SOCKET_TIMEOUT: socket timeout interval in Seconds
 #define MQTT_SOCKET_TIMEOUT 15
@@ -115,10 +115,10 @@ public:
    boolean connect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage);
    void disconnect();
    boolean publish(const char* topic, const char* payload);
-   boolean publish(const char* topic, const char* payload, boolean retained);
+   boolean publish(const char* topic, const char* payload, uint8_t qos, boolean retained);
    boolean publish(const char* topic, const uint8_t * payload, unsigned int plength);
-   boolean publish(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained);
-   boolean publish_P(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained);
+   boolean publish(const char* topic, const uint8_t * payload, unsigned int plength, uint8_t qos, boolean retained);
+   boolean publish_P(const char* topic, const uint8_t * payload, unsigned int plength, uint8_t qos, boolean retained);
    boolean subscribe(const char* topic);
    boolean subscribe(const char* topic, uint8_t qos);
    boolean unsubscribe(const char* topic);


### PR DESCRIPTION
- default MQTT_KEEPALIVE increased to 30 seconds
- esp8266 example updated with
  1) onDisconnected callback
  2) non blocking reconnect
  3) authentication
  4) last will message
  5) payload cast to string
- loop() now processes ALL available mqtt packets in the tcp buffer, not just the first
- publish(), subscribe() and unsubscribe() calls are preceded by loop() call to process incoming messages (and ACKS) without filling the TCP buffer when multiple pub/sub actions are performed
- publish() now supports QoS 0, 1 and 2. See the updated readme for more info
- improved comments in readPacket(uint8_t\* lengthLength) to better understand what it does

Signed-off-by: Stefano Semeraro semeraro.stefano@hotmail.it

Resolve #98, #59, #55 
