### PR TITLE
Use std::function on ESP8266 platform.

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -570,7 +570,7 @@ PubSubClient& PubSubClient::setServer(const char * domain, uint16_t port) {
     return *this;
 }
 
-PubSubClient& PubSubClient::setCallback(void(*callback)(char*,uint8_t*,unsigned int)){
+PubSubClient& PubSubClient::setCallback(MQTT_CALLBACK_SIGNATURE) {
     this->callback = callback;
     return *this;
 }

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -11,7 +11,6 @@
 #include "IPAddress.h"
 #include "Client.h"
 #include "Stream.h"
-#include <functional>
 
 #define MQTT_VERSION_3_1      3
 #define MQTT_VERSION_3_1_1    4
@@ -67,6 +66,7 @@
 #define MQTTQOS2        (2 << 1)
 
 #ifdef ESP8266
+#include <functional>
 #define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, uint32_t)> callback
 #else
 #define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, uint32_t)

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -66,7 +66,11 @@
 #define MQTTQOS1        (1 << 1)
 #define MQTTQOS2        (2 << 1)
 
+#ifdef ESP8266
 #define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, uint32_t)> callback
+#else
+#define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, uint32_t)
+#endif
 
 class PubSubClient {
 private:

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -11,6 +11,7 @@
 #include "IPAddress.h"
 #include "Client.h"
 #include "Stream.h"
+#include <functional>
 
 #define MQTT_VERSION_3_1      3
 #define MQTT_VERSION_3_1_1    4
@@ -65,7 +66,7 @@
 #define MQTTQOS1        (1 << 1)
 #define MQTTQOS2        (2 << 1)
 
-#define MQTT_CALLBACK_SIGNATURE void (*callback)(char*,uint8_t*,unsigned int)
+#define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, uint32_t)> callback
 
 class PubSubClient {
 private:


### PR DESCRIPTION
As discussed in #117.  For non-ESP8266 platforms, `<functional>` is not available; for these platforms, the only change is to use MQTT_CALLBACK_SIGNATURE in the definition of `PubSubClient::setCallback`, which seems like it was just an oversight anyway.