### PR TITLE
Added an API in order to auto-negotiate protocol 3.1  vs 3.1.1 at runtime

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -24,6 +24,7 @@ setServer	KEYWORD2
 setCallback	KEYWORD2
 setClient	KEYWORD2
 setStream	KEYWORD2
+setProtocol KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -5,19 +5,20 @@
 */
 
 #include "PubSubClient.h"
-#include "Arduino.h"
 
 PubSubClient::PubSubClient() {
     this->_state = MQTT_DISCONNECTED;
     this->_client = NULL;
     this->stream = NULL;
     setCallback(NULL);
+    setProtocol(MQTT_VERSION);
 }
 
 PubSubClient::PubSubClient(Client& client) {
     this->_state = MQTT_DISCONNECTED;
     setClient(client);
     this->stream = NULL;
+    setProtocol(MQTT_VERSION);
 }
 
 PubSubClient::PubSubClient(IPAddress addr, uint16_t port, Client& client) {
@@ -25,12 +26,14 @@ PubSubClient::PubSubClient(IPAddress addr, uint16_t port, Client& client) {
     setServer(addr, port);
     setClient(client);
     this->stream = NULL;
+    setProtocol(MQTT_VERSION);
 }
 PubSubClient::PubSubClient(IPAddress addr, uint16_t port, Client& client, Stream& stream) {
     this->_state = MQTT_DISCONNECTED;
     setServer(addr,port);
     setClient(client);
     setStream(stream);
+    setProtocol(MQTT_VERSION);
 }
 PubSubClient::PubSubClient(IPAddress addr, uint16_t port, MQTT_CALLBACK_SIGNATURE, Client& client) {
     this->_state = MQTT_DISCONNECTED;
@@ -38,6 +41,7 @@ PubSubClient::PubSubClient(IPAddress addr, uint16_t port, MQTT_CALLBACK_SIGNATUR
     setCallback(callback);
     setClient(client);
     this->stream = NULL;
+    setProtocol(MQTT_VERSION);
 }
 PubSubClient::PubSubClient(IPAddress addr, uint16_t port, MQTT_CALLBACK_SIGNATURE, Client& client, Stream& stream) {
     this->_state = MQTT_DISCONNECTED;
@@ -45,6 +49,7 @@ PubSubClient::PubSubClient(IPAddress addr, uint16_t port, MQTT_CALLBACK_SIGNATUR
     setCallback(callback);
     setClient(client);
     setStream(stream);
+    setProtocol(MQTT_VERSION);
 }
 
 PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, Client& client) {
@@ -52,12 +57,14 @@ PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, Client& client) {
     setServer(ip, port);
     setClient(client);
     this->stream = NULL;
+    setProtocol(MQTT_VERSION);
 }
 PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, Client& client, Stream& stream) {
     this->_state = MQTT_DISCONNECTED;
     setServer(ip,port);
     setClient(client);
     setStream(stream);
+    setProtocol(MQTT_VERSION);
 }
 PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, MQTT_CALLBACK_SIGNATURE, Client& client) {
     this->_state = MQTT_DISCONNECTED;
@@ -65,6 +72,7 @@ PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, MQTT_CALLBACK_SIGNATURE, 
     setCallback(callback);
     setClient(client);
     this->stream = NULL;
+    setProtocol(MQTT_VERSION);
 }
 PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, MQTT_CALLBACK_SIGNATURE, Client& client, Stream& stream) {
     this->_state = MQTT_DISCONNECTED;
@@ -72,6 +80,7 @@ PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, MQTT_CALLBACK_SIGNATURE, 
     setCallback(callback);
     setClient(client);
     setStream(stream);
+    setProtocol(MQTT_VERSION);
 }
 
 PubSubClient::PubSubClient(const char* domain, uint16_t port, Client& client) {
@@ -79,12 +88,14 @@ PubSubClient::PubSubClient(const char* domain, uint16_t port, Client& client) {
     setServer(domain,port);
     setClient(client);
     this->stream = NULL;
+    setProtocol(MQTT_VERSION);
 }
 PubSubClient::PubSubClient(const char* domain, uint16_t port, Client& client, Stream& stream) {
     this->_state = MQTT_DISCONNECTED;
     setServer(domain,port);
     setClient(client);
     setStream(stream);
+    setProtocol(MQTT_VERSION);
 }
 PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGNATURE, Client& client) {
     this->_state = MQTT_DISCONNECTED;
@@ -92,6 +103,7 @@ PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGN
     setCallback(callback);
     setClient(client);
     this->stream = NULL;
+    setProtocol(MQTT_VERSION);
 }
 PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGNATURE, Client& client, Stream& stream) {
     this->_state = MQTT_DISCONNECTED;
@@ -99,6 +111,7 @@ PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGN
     setCallback(callback);
     setClient(client);
     setStream(stream);
+    setProtocol(MQTT_VERSION);
 }
 
 boolean PubSubClient::connect(const char *id) {
@@ -128,16 +141,15 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
             uint16_t length = 5;
             unsigned int j;
 
-#if MQTT_VERSION == MQTT_VERSION_3_1
-            uint8_t d[9] = {0x00,0x06,'M','Q','I','s','d','p', MQTT_VERSION};
-#define MQTT_HEADER_VERSION_LENGTH 9
-#elif MQTT_VERSION == MQTT_VERSION_3_1_1
-            uint8_t d[7] = {0x00,0x04,'M','Q','T','T',MQTT_VERSION};
-#define MQTT_HEADER_VERSION_LENGTH 7
-#endif
-            for (j = 0;j<MQTT_HEADER_VERSION_LENGTH;j++) {
-                buffer[length++] = d[j];
-            }
+			if ( protocolType==MQTT_VERSION_3_1 ) {
+				const uint8_t d[9] = {0x00,0x06,'M','Q','I','s','d','p', MQTT_VERSION_3_1};
+				for ( j=0;j<sizeof(d);j++ )
+                	buffer[length++] = d[j];            
+			} else {
+      			const uint8_t d[7] = {0x00,0x04,'M','Q','T','T',MQTT_VERSION_3_1_1};
+				for ( j=0;j<sizeof(d);j++ )
+                	buffer[length++] = d[j];            
+			}
 
             uint8_t v;
             if (willTopic) {
@@ -174,12 +186,16 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
             write(MQTTCONNECT,buffer,length-5);
 
             lastInActivity = lastOutActivity = millis();
-
+			
             while (!_client->available()) {
                 unsigned long t = millis();
                 if (t-lastInActivity >= ((int32_t) MQTT_SOCKET_TIMEOUT*1000UL)) {
                     _state = MQTT_CONNECTION_TIMEOUT;
                     _client->stop();
+
+                    // Next time, Try to Switch Protocol if client not responding 
+                    protocolType = (protocolType==MQTT_VERSION_3_1_1) ? MQTT_VERSION_3_1 : MQTT_VERSION_3_1_1; 
+                    
                     return false;
                 }
             }
@@ -210,7 +226,7 @@ boolean PubSubClient::readByte(uint8_t * result) {
    uint32_t previousMillis = millis();
    while(!_client->available()) {
      uint32_t currentMillis = millis();
-     if(currentMillis - previousMillis >= ((int32_t) MQTT_SOCKET_TIMEOUT * 1000)){
+     if(currentMillis - previousMillis >= ((int32_t) MQTT_SOCKET_TIMEOUT*1000UL)){
        return false;
      }
    }
@@ -551,6 +567,12 @@ boolean PubSubClient::connected() {
     }
     return rc;
 }
+
+PubSubClient& PubSubClient::setProtocol( const ProtocolType protocolType )
+{
+	this->protocolType = protocolType;
+	return *this;
+}	
 
 PubSubClient& PubSubClient::setServer(uint8_t * ip, uint16_t port) {
     IPAddress addr(ip[0],ip[1],ip[2],ip[3]);

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -7,13 +7,19 @@
 #ifndef PubSubClient_h
 #define PubSubClient_h
 
+#if defined(ARDUINO) && ARDUINO >= 100
 #include <Arduino.h>
+#else
+#include <WProgram.h>
+#endif
 #include "IPAddress.h"
 #include "Client.h"
 #include "Stream.h"
 
-#define MQTT_VERSION_3_1      3
-#define MQTT_VERSION_3_1_1    4
+typedef enum {
+	MQTT_VERSION_3_1      = 0x3,
+	MQTT_VERSION_3_1_1    = 0x4
+} ProtocolType;
 
 // MQTT_VERSION : Pick the version
 //#define MQTT_VERSION MQTT_VERSION_3_1
@@ -86,6 +92,8 @@ private:
    uint16_t port;
    Stream* stream;
    int _state;
+   ProtocolType protocolType;
+   
 public:
    PubSubClient();
    PubSubClient(Client& client);
@@ -108,6 +116,7 @@ public:
    PubSubClient& setCallback(MQTT_CALLBACK_SIGNATURE);
    PubSubClient& setClient(Client& client);
    PubSubClient& setStream(Stream& stream);
+   PubSubClient& setProtocol( const ProtocolType protocolType );
 
    boolean connect(const char* id);
    boolean connect(const char* id, const char* user, const char* pass);


### PR DESCRIPTION
Hello, 
I integrated this library in a domotic project that uses Domoticz.
I had a problem interfacing Mosquitto Broker on Ubuntu 12.04 simply because there the protocol 
was "old" 3.1 and the pubsubclient library instead was statically compiled to 3.1.1.
Since I noticed that with few changes it was feasible to switch the protocol at runtime, I thought that
it make sense to add a simple API to set the protocol and a simple kind of auto-negotiation (i.e. auto ping-pong protocol switching when a timeout is reached when trying to connect to the broker)
  
I checked the code was working as expected by setting initially the protocol to 3.1.1 and connecting
to the broker supporting the 3.1: 1st time the timeout was reached, but at the 2nd trial the library switched to 3.1.1 automatically. 
I think that this is useful to enhance the reliability of the library..
