### PR TITLE
Use random MQTT client ID in example sketch

### DIFF
--- a/examples/mqtt_esp8266/mqtt_esp8266.ino
+++ b/examples/mqtt_esp8266/mqtt_esp8266.ino
@@ -53,6 +53,8 @@ void setup_wifi() {
     Serial.print(".");
   }
 
+  randomSeed(micros());
+
   Serial.println("");
   Serial.println("WiFi connected");
   Serial.println("IP address: ");
@@ -83,8 +85,11 @@ void reconnect() {
   // Loop until we're reconnected
   while (!client.connected()) {
     Serial.print("Attempting MQTT connection...");
+    // Create a random client ID
+    String clientId = "ESP8266Client-";
+    clientId += String(random(0xffff), HEX);
     // Attempt to connect
-    if (client.connect("ESP8266Client")) {
+    if (client.connect(clientId.c_str())) {
       Serial.println("connected");
       // Once connected, publish an announcement...
       client.publish("outTopic", "hello world");


### PR DESCRIPTION
Many users load the sketch having only changed WiFi SSID and password. When multiple users attempt to connect to the same broker using same client ID, they get rejected. Currently the chances of connecting to broker.mqtt-dashboard.com using "ESP8266Client" ID are fairly slim. This change adds a random number to the client ID, increasing chances of connection for new users of this library.