### PR TITLE
Rework packet handling

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -125,7 +125,7 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
         if (result == 1) {
             nextMsgId = 1;
             // Leave room in the buffer for header and variable length field
-            uint16_t length = 5;
+            uint32_t length = 5;
             unsigned int j;
 
 #if MQTT_VERSION == MQTT_VERSION_3_1
@@ -183,11 +183,16 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
                     return false;
                 }
             }
-            uint8_t llen;
-            uint16_t len = readPacket(&llen);
-
-            if (len == 4) {
-                if (buffer[3] == 0) {
+            uint8_t type;
+            readPacketHeader(&type, &length);
+            _state = MQTT_CONNECT_FAILED;
+            if (MQTTTYPE(type) == MQTTCONNACK && length == 2) {
+                uint8_t connState;
+                
+                if(!readByte(&connState)) return false; // the first byte is a flag field, just skip it
+                if(!readByte(&connState)) return false;
+                
+                if (connState == 0) {
                     lastInActivity = millis();
                     pingOutstanding = false;
                     _state = MQTT_CONNECTED;
@@ -197,8 +202,6 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
                 }
             }
             _client->stop();
-        } else {
-            _state = MQTT_CONNECT_FAILED;
         }
         return false;
     }
@@ -229,54 +232,105 @@ boolean PubSubClient::readByte(uint8_t * result, uint16_t * index){
   return false;
 }
 
-uint16_t PubSubClient::readPacket(uint8_t* lengthLength) {
-    uint16_t len = 0;
-    if(!readByte(buffer, &len)) return 0;
-    bool isPublish = (buffer[0]&0xF0) == MQTTPUBLISH;
-    uint32_t multiplier = 1;
-    uint16_t length = 0;
-    uint8_t digit = 0;
-    uint16_t skip = 0;
-    uint8_t start = 0;
-
+boolean PubSubClient::readPacketHeader(uint8_t* type, uint32_t* length) {
+    uint8_t lengthPos = 0;
+    uint8_t digit;
+    
+    if(!readByte(type)) return false;
+    
+    *length = 0;
     do {
-        if(!readByte(&digit)) return 0;
-        buffer[len++] = digit;
-        length += (digit & 127) * multiplier;
-        multiplier *= 128;
+        *length <<= (7*(lengthPos++));
+        if(!readByte(&digit)) return false;
+        *length += (digit & 127);
     } while ((digit & 128) != 0);
-    *lengthLength = len-1;
+    
+    return true;
+}
 
-    if (isPublish) {
-        // Read in topic length to calculate bytes to skip over for Stream writing
-        if(!readByte(buffer, &len)) return 0;
-        if(!readByte(buffer, &len)) return 0;
-        skip = (buffer[*lengthLength+1]<<8)+buffer[*lengthLength+2];
-        start = 2;
-        if (buffer[0]&MQTTQOS1) {
-            // skip message id
-            skip += 2;
+boolean PubSubClient::handlePublishPacket(uint8_t type, uint32_t remaining) {
+    uint16_t topicLength;
+    uint8_t digit;
+    uint16_t msgId;
+    
+    if(remaining < 2) return false;
+    
+    if(!readByte(&digit)) return false;
+    topicLength = digit << 8;
+    if(!readByte(&digit)) return false;
+    topicLength += digit;
+    
+    remaining -= 2;
+    if(topicLength > remaining) return false;
+    
+    if(topicLength > MQTT_MAX_PACKET_SIZE) { // ignore big packets
+        if(MQTTQOS(type) != MQTTQOS0) { // we have to read the msgId
+            skipData(topicLength);
+            
+            if(remaining < 2) return false;
+    
+            if(!readByte(&digit)) return false;
+            msgId = digit << 8;
+            if(!readByte(&digit)) return false;
+            msgId += digit;
+    
+            remaining -= 2;
+            
+            sendPubAck(msgId);
         }
+        skipData(remaining);
+        return true;
     }
-
-    for (uint16_t i = start;i<length;i++) {
-        if(!readByte(&digit)) return 0;
-        if (this->stream) {
-            if (isPublish && len-*lengthLength-2>skip) {
-                this->stream->write(digit);
-            }
-        }
-        if (len < MQTT_MAX_PACKET_SIZE) {
-            buffer[len] = digit;
-        }
-        len++;
+    
+    char topic[topicLength + 1];
+    for(uint16_t i = 0; i < topicLength; i++) {
+        if(!readByte((uint8_t*)&topic[i])) return false;
+        remaining--;
     }
-
-    if (!this->stream && len > MQTT_MAX_PACKET_SIZE) {
-        len = 0; // This will cause the packet to be ignored.
+    topic[topicLength] = 0;
+    
+    if(MQTTQOS(type) != MQTTQOS0) {
+        if(remaining < 2) return false;
+    
+        if(!readByte(&digit)) return false;
+        msgId = digit << 8;
+        if(!readByte(&digit)) return false;
+        msgId += digit;
+    
+        remaining -= 2;
     }
+    
+    
+    if(remaining > MQTT_MAX_PACKET_SIZE) { // ignore big packets
+        skipData(remaining);
+        if(MQTTQOS(type) != MQTTQOS0) sendPubAck(msgId);
+            
+        return true;
+    }
+    
+    uint16_t pos = 0;
+    while(remaining-- != 0) if(!readByte(buffer, &pos)) return false;
+    
+    if(callback) callback(topic, buffer, pos);
+    
+    if(MQTTQOS(type) != MQTTQOS0) sendPubAck(msgId);
+    
+    return true;
+}
+boolean PubSubClient::sendPubAck(uint16_t msgId) {
+    buffer[0] = MQTTPUBACK;
+    buffer[1] = 2;
+    buffer[2] = (msgId >> 8);
+    buffer[3] = (msgId & 0xFF);
+    _client->write(buffer,4);
+}
 
-    return len;
+boolean PubSubClient::skipData(uint32_t remaining) {
+    uint8_t digit;
+    while(remaining-- != 0) {
+         if(!readByte(&digit)) return false;
+    }
+    return true;
 }
 
 boolean PubSubClient::loop() {
@@ -297,46 +351,34 @@ boolean PubSubClient::loop() {
             }
         }
         if (_client->available()) {
-            uint8_t llen;
-            uint16_t len = readPacket(&llen);
-            uint16_t msgId = 0;
-            uint8_t *payload;
-            if (len > 0) {
-                lastInActivity = t;
-                uint8_t type = buffer[0]&0xF0;
-                if (type == MQTTPUBLISH) {
-                    if (callback) {
-                        uint16_t tl = (buffer[llen+1]<<8)+buffer[llen+2];
-                        char topic[tl+1];
-                        for (uint16_t i=0;i<tl;i++) {
-                            topic[i] = buffer[llen+3+i];
-                        }
-                        topic[tl] = 0;
-                        // msgId only present for QOS>0
-                        if ((buffer[0]&0x06) == MQTTQOS1) {
-                            msgId = (buffer[llen+3+tl]<<8)+buffer[llen+3+tl+1];
-                            payload = buffer+llen+3+tl+2;
-                            callback(topic,payload,len-llen-3-tl-2);
-
-                            buffer[0] = MQTTPUBACK;
-                            buffer[1] = 2;
-                            buffer[2] = (msgId >> 8);
-                            buffer[3] = (msgId & 0xFF);
-                            _client->write(buffer,4);
-                            lastOutActivity = t;
-
-                        } else {
-                            payload = buffer+llen+3+tl;
-                            callback(topic,payload,len-llen-3-tl);
-                        }
-                    }
-                } else if (type == MQTTPINGREQ) {
-                    buffer[0] = MQTTPINGRESP;
-                    buffer[1] = 0;
-                    _client->write(buffer,2);
-                } else if (type == MQTTPINGRESP) {
+            uint8_t type;
+            uint32_t length;
+            if(!readPacketHeader(&type, &length)) {
+                this->_state = MQTT_CONNECTION_LOST;
+                _client->stop();
+                return false;
+            }
+            lastInActivity = t;
+            
+            switch(MQTTTYPE(type)) {
+                case MQTTPUBLISH:
+                    handlePublishPacket(type, length);
+                    break;
+                case MQTTPINGRESP:
                     pingOutstanding = false;
-                }
+                    if(length != 0) {
+                        this->_state = MQTT_CONNECTION_LOST;
+                        _client->stop();
+                        return false;
+                    }
+                    break;
+                case MQTTSUBACK: // we ignore this packet
+                    if(!skipData(length)) return false;
+                    break;
+                default:
+                    this->_state = MQTT_CONNECTION_LOST;
+                    _client->stop();
+                    return false;
             }
         }
         return true;

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -53,21 +53,24 @@
 #define MQTT_CONNECT_BAD_CREDENTIALS 4
 #define MQTT_CONNECT_UNAUTHORIZED    5
 
-#define MQTTCONNECT     1 << 4  // Client request to connect to Server
-#define MQTTCONNACK     2 << 4  // Connect Acknowledgment
-#define MQTTPUBLISH     3 << 4  // Publish message
-#define MQTTPUBACK      4 << 4  // Publish Acknowledgment
-#define MQTTPUBREC      5 << 4  // Publish Received (assured delivery part 1)
-#define MQTTPUBREL      6 << 4  // Publish Release (assured delivery part 2)
-#define MQTTPUBCOMP     7 << 4  // Publish Complete (assured delivery part 3)
-#define MQTTSUBSCRIBE   8 << 4  // Client Subscribe request
-#define MQTTSUBACK      9 << 4  // Subscribe Acknowledgment
-#define MQTTUNSUBSCRIBE 10 << 4 // Client Unsubscribe request
-#define MQTTUNSUBACK    11 << 4 // Unsubscribe Acknowledgment
-#define MQTTPINGREQ     12 << 4 // PING Request
-#define MQTTPINGRESP    13 << 4 // PING Response
-#define MQTTDISCONNECT  14 << 4 // Client is Disconnecting
+#define MQTTCONNECT     1 << 4  // Client request to connect to Server        C->S
+#define MQTTCONNACK     2 << 4  // Connect Acknowledgment                     S->C
+#define MQTTPUBLISH     3 << 4  // Publish message                            C<>S
+#define MQTTPUBACK      4 << 4  // Publish Acknowledgment                     C<>S
+#define MQTTPUBREC      5 << 4  // Publish Received (assured delivery part 1) C<>S
+#define MQTTPUBREL      6 << 4  // Publish Release (assured delivery part 2)  C<>S
+#define MQTTPUBCOMP     7 << 4  // Publish Complete (assured delivery part 3) C<>S
+#define MQTTSUBSCRIBE   8 << 4  // Client Subscribe request                   C->S
+#define MQTTSUBACK      9 << 4  // Subscribe Acknowledgment                   S->C
+#define MQTTUNSUBSCRIBE 10 << 4 // Client Unsubscribe request                 C->S
+#define MQTTUNSUBACK    11 << 4 // Unsubscribe Acknowledgment                 S->C
+#define MQTTPINGREQ     12 << 4 // PING Request                               C->S
+#define MQTTPINGRESP    13 << 4 // PING Response                              S->C
+#define MQTTDISCONNECT  14 << 4 // Client is Disconnecting                    C->S
 #define MQTTReserved    15 << 4 // Reserved
+
+#define MQTTTYPE(t)     ((t)&0xF0)
+#define MQTTQOS(t)      ((t)&0x0E)
 
 #define MQTTQOS0        (0 << 1)
 #define MQTTQOS1        (1 << 1)

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -92,7 +92,10 @@ private:
    unsigned long lastInActivity;
    bool pingOutstanding;
    MQTT_CALLBACK_SIGNATURE;
-   uint16_t readPacket(uint8_t*);
+   boolean readPacketHeader(uint8_t* type, uint32_t* length);
+   boolean handlePublishPacket(uint8_t type, uint32_t remaining);
+   boolean sendPubAck(uint16_t msgId);
+   boolean skipData(uint32_t remaining);
    boolean readByte(uint8_t * result);
    boolean readByte(uint8_t * result, uint16_t * index);
    boolean write(uint8_t header, uint8_t* buf, uint16_t length);


### PR DESCRIPTION
I've started to add a new callback which gets the payload length and the topic before the data appears in the stream.
But first I cleaned up the packet handling up. The new callback will be in a separate pull request.