### PR TITLE
Allow custom values for MQTT_KEEPALIVE, MQTT_SOCKET_TIMEOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Full API documentation is available here: http://pubsubclient.knolleary.net
  - It can only publish QoS 0 messages. It can subscribe at QoS 0 or QoS 1.
  - The maximum message size, including header, is **128 bytes** by default. This
    is configurable via `MQTT_MAX_PACKET_SIZE` in `PubSubClient.h`.
- - The keepalive interval is set to 15 seconds by default. This is configurable
-   via `MQTT_KEEPALIVE` in `PubSubClient.h`.
  - The client uses MQTT 3.1.1 by default. It can be changed to use MQTT 3.1 by
    changing value of `MQTT_VERSION` in `PubSubClient.h`.
 

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -101,35 +101,19 @@ PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGN
     setStream(stream);
 }
 
-boolean PubSubClient::connect(const char *id) {
-    return connect(id,NULL,NULL,0,0,0,0,0);
+boolean PubSubClient::connect(const char *id, uint16_t keepAlive, uint16_t socketTimeout) {
+    return connect(id,NULL,NULL,0,0,0,0,keepAlive,socketTimeout);
 }
 
-boolean PubSubClient::connect(const char *id, uint16_t keepAlive) {
-    return connect(id,NULL,NULL,0,0,0,0,keepAlive);
+boolean PubSubClient::connect(const char *id, const char *user, const char *pass, uint16_t keepAlive, uint16_t socketTimeout) {
+    return connect(id,user,pass,0,0,0,0,keepAlive,socketTimeout);
 }
 
-boolean PubSubClient::connect(const char *id, const char *user, const char *pass) {
-    return connect(id,user,pass,0,0,0,0,0);
+boolean PubSubClient::connect(const char *id, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, uint16_t keepAlive, uint16_t socketTimeout) {
+    return connect(id,NULL,NULL,willTopic,willQos,willRetain,willMessage,keepAlive,socketTimeout);
 }
 
-boolean PubSubClient::connect(const char *id, const char *user, const char *pass, uint16_t keepAlive) {
-    return connect(id,user,pass,0,0,0,0,keepAlive);
-}
-
-boolean PubSubClient::connect(const char *id, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage) {
-    return connect(id,NULL,NULL,willTopic,willQos,willRetain,willMessage,0);
-}
-
-boolean PubSubClient::connect(const char *id, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, uint16_t keepAlive) {
-    return connect(id,NULL,NULL,willTopic,willQos,willRetain,willMessage,keepAlive);
-}
-
-boolean PubSubClient::connect(const char *id, const char *user, const char *pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage) {
-    return connect(id,NULL,NULL,willTopic,willQos,willRetain,willMessage,0);
-}
-
-boolean PubSubClient::connect(const char *id, const char *user, const char *pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, uint16_t keepAlive) {
+boolean PubSubClient::connect(const char *id, const char *user, const char *pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, uint16_t keepAlive, uint16_t socketTimeout) {
     if (!connected()) {
         int result = 0;
 
@@ -197,9 +181,15 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
 
             lastInActivity = lastOutActivity = millis();
 
+            if (socketTimeout > 0) {
+                this->socketTimeout = socketTimeout;
+            } else {
+                this->socketTimeout = 15;
+            }
+
             while (!_client->available()) {
                 unsigned long t = millis();
-                if (t-lastInActivity >= ((int32_t) MQTT_SOCKET_TIMEOUT*1000UL)) {
+                if (t-lastInActivity >= ((int32_t) this->socketTimeout*1000UL)) {
                     _state = MQTT_CONNECTION_TIMEOUT;
                     _client->stop();
                     return false;
@@ -232,7 +222,7 @@ boolean PubSubClient::readByte(uint8_t * result) {
    uint32_t previousMillis = millis();
    while(!_client->available()) {
      uint32_t currentMillis = millis();
-     if(currentMillis - previousMillis >= ((int32_t) MQTT_SOCKET_TIMEOUT * 1000)){
+     if(currentMillis - previousMillis >= ((int32_t) this->socketTimeout * 1000)){
        return false;
      }
    }
@@ -604,6 +594,11 @@ PubSubClient& PubSubClient::setClient(Client& client){
 
 PubSubClient& PubSubClient::setStream(Stream& stream){
     this->stream = &stream;
+    return *this;
+}
+
+PubSubClient& PubSubClient::setTimeout(uint16_t socketTimeout){
+    this->socketTimeout = socketTimeout;
     return *this;
 }
 

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -26,11 +26,6 @@
 #define MQTT_MAX_PACKET_SIZE 128
 #endif
 
-// MQTT_SOCKET_TIMEOUT: socket timeout interval in Seconds
-#ifndef MQTT_SOCKET_TIMEOUT
-#define MQTT_SOCKET_TIMEOUT 15
-#endif
-
 // MQTT_MAX_TRANSFER_SIZE : limit how much data is passed to the network client
 //  in each write call. Needed for the Arduino Wifi Shield. Leave undefined to
 //  pass the entire MQTT packet in each write call.
@@ -95,6 +90,7 @@ private:
    Stream* stream;
    int _state;
    uint16_t keepAlive;
+   uint16_t socketTimeout;
 public:
    PubSubClient();
    PubSubClient(Client& client);
@@ -117,15 +113,12 @@ public:
    PubSubClient& setCallback(MQTT_CALLBACK_SIGNATURE);
    PubSubClient& setClient(Client& client);
    PubSubClient& setStream(Stream& stream);
+   PubSubClient& setTimeout(uint16_t socketTimeout);
 
-   boolean connect(const char* id);
-   boolean connect(const char* id, uint16_t keepAlive);
-   boolean connect(const char* id, const char* user, const char* pass);
-   boolean connect(const char* id, const char* user, const char* pass, uint16_t keepAlive);
-   boolean connect(const char* id, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage);
-   boolean connect(const char* id, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, uint16_t keepAlive);
-   boolean connect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage);
-   boolean connect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, uint16_t keepAlive);
+   boolean connect(const char* id, uint16_t keepAlive=15, uint16_t socketTimeout=15);
+   boolean connect(const char* id, const char* user, const char* pass, uint16_t keepAlive=15, uint16_t socketTimeout=15);
+   boolean connect(const char* id, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, uint16_t keepAlive=15, uint16_t socketTimeout=15);
+   boolean connect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, uint16_t keepAlive=15, uint16_t socketTimeout=15);
    void disconnect();
    boolean publish(const char* topic, const char* payload);
    boolean publish(const char* topic, const char* payload, boolean retained);

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -26,11 +26,6 @@
 #define MQTT_MAX_PACKET_SIZE 128
 #endif
 
-// MQTT_KEEPALIVE : keepAlive interval in Seconds
-#ifndef MQTT_KEEPALIVE
-#define MQTT_KEEPALIVE 15
-#endif
-
 // MQTT_SOCKET_TIMEOUT: socket timeout interval in Seconds
 #ifndef MQTT_SOCKET_TIMEOUT
 #define MQTT_SOCKET_TIMEOUT 15
@@ -99,6 +94,7 @@ private:
    uint16_t port;
    Stream* stream;
    int _state;
+   uint16_t keepAlive;
 public:
    PubSubClient();
    PubSubClient(Client& client);
@@ -123,9 +119,13 @@ public:
    PubSubClient& setStream(Stream& stream);
 
    boolean connect(const char* id);
+   boolean connect(const char* id, uint16_t keepAlive);
    boolean connect(const char* id, const char* user, const char* pass);
+   boolean connect(const char* id, const char* user, const char* pass, uint16_t keepAlive);
    boolean connect(const char* id, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage);
+   boolean connect(const char* id, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, uint16_t keepAlive);
    boolean connect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage);
+   boolean connect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, uint16_t keepAlive);
    void disconnect();
    boolean publish(const char* topic, const char* payload);
    boolean publish(const char* topic, const char* payload, boolean retained);


### PR DESCRIPTION
Addresses issue https://github.com/knolleary/pubsubclient/issues/175. I'm not sure how you feel about optional values in the header declaration, so if this is annoying for you feel free to just take the first commit.
