### PR TITLE
Add QOS 1 Publish capability 

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,14 +12,14 @@ PubSubClient	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-connect 	KEYWORD2
+connect 	  KEYWORD2
 disconnect 	KEYWORD2
-publish 	KEYWORD2
+publish 	  KEYWORD2
 publish_P 	KEYWORD2
-publish_Q1 KEYWORD2
+publish_Q1  KEYWORD2
 subscribe 	KEYWORD2
 unsubscribe 	KEYWORD2
-loop 	KEYWORD2
+loop 	      KEYWORD2
 connected 	KEYWORD2
 setServer	KEYWORD2
 setCallback	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -16,6 +16,7 @@ connect 	KEYWORD2
 disconnect 	KEYWORD2
 publish 	KEYWORD2
 publish_P 	KEYWORD2
+publish_Q1 KEYWORD2
 subscribe 	KEYWORD2
 unsubscribe 	KEYWORD2
 loop 	KEYWORD2

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -35,11 +35,10 @@
 #ifndef MQTT_SOCKET_TIMEOUT
 #define MQTT_SOCKET_TIMEOUT 15
 #endif
-                           // RCC MQTT_QOS1_WAIT_TIME:  timeout for wait for QOS1 PUBACK interval in ms
-#ifndef MQTT_QOS1_WAIT_TIME                                     //rcc
-#define MQTT_QOS1_WAIT_TIME 100                                 //rcc
-#endif                                                          //rcc
-
+                           //     MQTT_QOS1_WAIT_TIME:  timeout for wait for QOS1 PUBACK interval in ms
+#ifndef MQTT_QOS1_WAIT_TIME                                     //
+#define MQTT_QOS1_WAIT_TIME 100                                 //
+#endif                                                          //
 
 // MQTT_MAX_TRANSFER_SIZE : limit how much data is passed to the network client
 //  in each write call. Needed for the Arduino Wifi Shield. Leave undefined to
@@ -104,15 +103,15 @@ private:
    uint16_t port;
    Stream* stream;
    int _state;
-                  //rcc added         for  QOS 1 publication and resend
-   uint32_t   _QOS1_SENT_TIME;                              //rcc
-   boolean   _QOS1Acknowledged;                             //rcc
-   int       _QOS1MSGID;                                    //rcc
-   uint8_t   _SentQOS1buffer[MQTT_MAX_PACKET_SIZE];         //rcc
-   char      _SentQOS1Topic[20];                                // rcc    is 20 enough??      
-   uint16_t  _SENTQOS1Length;                                // rcc
+        //               added         for  QOS 1 publication and resend
+   uint32_t   _QOS1_SENT_TIME;                              //
+   boolean   _QOS1Acknowledged;                             //
+   int       _QOS1MSGID;                                    //
+   uint8_t   _SentQOS1buffer[MQTT_MAX_PACKET_SIZE];         //
+   char      _SentQOS1Topic[40];                            //  is 40 enough??      
+   uint16_t  _SENTQOS1Length;                               // 
+        // 
 public:
- 
    PubSubClient();
    PubSubClient(Client& client);
    PubSubClient(IPAddress, uint16_t, Client& client);
@@ -144,8 +143,8 @@ public:
    boolean publish(const char* topic, const char* payload, boolean retained);
    boolean publish(const char* topic, const uint8_t * payload, unsigned int plength);
    boolean publish(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained);  
-   boolean publish_Q1(const char* topic, const uint8_t* payload, unsigned int plength);                                                           //rcc new
-   boolean publish_Q1(const char* topic, const uint8_t* payload, unsigned int plength, boolean retained, boolean QOS1_MSG_Repeat); //rcc new
+   boolean publish_Q1(const char* topic, const uint8_t * payload, unsigned int plength);
+   boolean publish_Q1(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained, boolean QOS1_MSG_Repeat);
    boolean publish_P(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained);
    boolean subscribe(const char* topic);
    boolean subscribe(const char* topic, uint8_t qos);

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -35,6 +35,11 @@
 #ifndef MQTT_SOCKET_TIMEOUT
 #define MQTT_SOCKET_TIMEOUT 15
 #endif
+                           // RCC MQTT_QOS1_WAIT_TIME:  timeout for wait for QOS1 PUBACK interval in ms
+#ifndef MQTT_QOS1_WAIT_TIME                                     //rcc
+#define MQTT_QOS1_WAIT_TIME 100                                 //rcc
+#endif                                                          //rcc
+
 
 // MQTT_MAX_TRANSFER_SIZE : limit how much data is passed to the network client
 //  in each write call. Needed for the Arduino Wifi Shield. Leave undefined to
@@ -99,7 +104,15 @@ private:
    uint16_t port;
    Stream* stream;
    int _state;
+                  //rcc added         for  QOS 1 publication and resend
+   uint32_t   _QOS1_SENT_TIME;                              //rcc
+   boolean   _QOS1Acknowledged;                             //rcc
+   int       _QOS1MSGID;                                    //rcc
+   uint8_t   _SentQOS1buffer[MQTT_MAX_PACKET_SIZE];         //rcc
+   char      _SentQOS1Topic[20];                                // rcc    is 20 enough??      
+   uint16_t  _SENTQOS1Length;                                // rcc
 public:
+ 
    PubSubClient();
    PubSubClient(Client& client);
    PubSubClient(IPAddress, uint16_t, Client& client);
@@ -130,7 +143,9 @@ public:
    boolean publish(const char* topic, const char* payload);
    boolean publish(const char* topic, const char* payload, boolean retained);
    boolean publish(const char* topic, const uint8_t * payload, unsigned int plength);
-   boolean publish(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained);
+   boolean publish(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained);  
+   boolean publish_Q1(const char* topic, const uint8_t* payload, unsigned int plength);                                                           //rcc new
+   boolean publish_Q1(const char* topic, const uint8_t* payload, unsigned int plength, boolean retained, boolean QOS1_MSG_Repeat); //rcc new
    boolean publish_P(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained);
    boolean subscribe(const char* topic);
    boolean subscribe(const char* topic, uint8_t qos);


### PR DESCRIPTION
I have added / hacked in a simple QOS 1 publish capability.
It adds a new boolean "publish_Q1" that includes a "save the last message" in variables: _SentQOS1buffer[MQTT_MAX_PACKET_SIZE],  _SentQOS1Topic[40]; and  _SENTQOS1Length;    

The topic length at 40 was ok for me, but should probably be increased. 
I had trouble at first with saving to these "last message/topic" variables so that i could resend using the same "Publish_Q1" code, 
A better approach would probably be to make a single stored message with the header, msg id and payload and then explicitly resend this if the PUBACK is not detected.? I was not sure how to achieve this simply.

It is limited to a single "stored message".

Cheers
Dagnall 
