### PR TITLE
Support for passing arguments to a callback

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -18,6 +18,7 @@ PubSubClient::PubSubClient(Client& client) {
     this->_state = MQTT_DISCONNECTED;
     setClient(client);
     this->stream = NULL;
+    setCallback(NULL);
 }
 
 PubSubClient::PubSubClient(IPAddress addr, uint16_t port, Client& client) {
@@ -25,12 +26,14 @@ PubSubClient::PubSubClient(IPAddress addr, uint16_t port, Client& client) {
     setServer(addr, port);
     setClient(client);
     this->stream = NULL;
+    setCallback(NULL);
 }
 PubSubClient::PubSubClient(IPAddress addr, uint16_t port, Client& client, Stream& stream) {
     this->_state = MQTT_DISCONNECTED;
-    setServer(addr,port);
+    setServer(addr, port);
     setClient(client);
     setStream(stream);
+    setCallback(NULL);
 }
 PubSubClient::PubSubClient(IPAddress addr, uint16_t port, MQTT_CALLBACK_SIGNATURE, Client& client) {
     this->_state = MQTT_DISCONNECTED;
@@ -41,8 +44,24 @@ PubSubClient::PubSubClient(IPAddress addr, uint16_t port, MQTT_CALLBACK_SIGNATUR
 }
 PubSubClient::PubSubClient(IPAddress addr, uint16_t port, MQTT_CALLBACK_SIGNATURE, Client& client, Stream& stream) {
     this->_state = MQTT_DISCONNECTED;
-    setServer(addr,port);
+    setServer(addr, port);
     setCallback(callback);
+    setClient(client);
+    setStream(stream);
+}
+
+PubSubClient::PubSubClient(IPAddress addr, uint16_t port, MQTT_CALLBACK_SIGNATURE_WITH_ARG, void* arg, Client& client) {
+    this->_state = MQTT_DISCONNECTED;
+    setServer(addr, port);
+    setCallback(callbackWithArg, arg);
+    setClient(client);
+    this->stream = NULL;
+}
+
+PubSubClient::PubSubClient(IPAddress addr, uint16_t port, MQTT_CALLBACK_SIGNATURE_WITH_ARG, void* arg, Client& client, Stream& stream) {
+    this->_state = MQTT_DISCONNECTED;
+    setServer(addr, port);
+    setCallback(callbackWithArg, arg);
     setClient(client);
     setStream(stream);
 }
@@ -52,6 +71,7 @@ PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, Client& client) {
     setServer(ip, port);
     setClient(client);
     this->stream = NULL;
+    setCallback(NULL);
 }
 PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, Client& client, Stream& stream) {
     this->_state = MQTT_DISCONNECTED;
@@ -74,17 +94,35 @@ PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, MQTT_CALLBACK_SIGNATURE, 
     setStream(stream);
 }
 
+PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, MQTT_CALLBACK_SIGNATURE_WITH_ARG, void* arg, Client& client) {
+    this->_state = MQTT_DISCONNECTED;
+    setServer(ip, port);
+    setCallback(callbackWithArg, arg);
+    setClient(client);
+    this->stream = NULL;
+}
+
+PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, MQTT_CALLBACK_SIGNATURE_WITH_ARG, void* arg, Client& client, Stream& stream) {
+    this->_state = MQTT_DISCONNECTED;
+    setServer(ip,port);
+    setCallback(callbackWithArg, arg);
+    setClient(client);
+    setStream(stream);
+}
+
 PubSubClient::PubSubClient(const char* domain, uint16_t port, Client& client) {
     this->_state = MQTT_DISCONNECTED;
     setServer(domain,port);
     setClient(client);
     this->stream = NULL;
+    setCallback(NULL);
 }
 PubSubClient::PubSubClient(const char* domain, uint16_t port, Client& client, Stream& stream) {
     this->_state = MQTT_DISCONNECTED;
     setServer(domain,port);
     setClient(client);
     setStream(stream);
+    setCallback(NULL);
 }
 PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGNATURE, Client& client) {
     this->_state = MQTT_DISCONNECTED;
@@ -97,6 +135,22 @@ PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGN
     this->_state = MQTT_DISCONNECTED;
     setServer(domain,port);
     setCallback(callback);
+    setClient(client);
+    setStream(stream);
+}
+
+PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGNATURE_WITH_ARG, void* arg, Client& client) {
+    this->_state = MQTT_DISCONNECTED;
+    setServer(domain,port);
+    setCallback(callbackWithArg, arg);
+    setClient(client);
+    this->stream = NULL;
+}
+
+PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGNATURE_WITH_ARG, void* arg, Client& client, Stream& stream) {
+    this->_state = MQTT_DISCONNECTED;
+    setServer(domain,port);
+    setCallback(callbackWithArg, arg);
     setClient(client);
     setStream(stream);
 }
@@ -305,7 +359,7 @@ boolean PubSubClient::loop() {
                 lastInActivity = t;
                 uint8_t type = buffer[0]&0xF0;
                 if (type == MQTTPUBLISH) {
-                    if (callback) {
+                    if (callback || (callbackWithArg && arg)) {
                         uint16_t tl = (buffer[llen+1]<<8)+buffer[llen+2]; /* topic length in bytes */
                         memmove(buffer+llen+2,buffer+llen+3,tl); /* move topic inside buffer 1 byte to front */
                         buffer[llen+2+tl] = 0; /* end the topic as a 'C' string with \x00 */
@@ -314,7 +368,11 @@ boolean PubSubClient::loop() {
                         if ((buffer[0]&0x06) == MQTTQOS1) {
                             msgId = (buffer[llen+3+tl]<<8)+buffer[llen+3+tl+1];
                             payload = buffer+llen+3+tl+2;
-                            callback(topic,payload,len-llen-3-tl-2);
+                            if (callback) {
+                                callback(topic,payload,len-llen-3-tl-2);
+                            } else {
+                                callbackWithArg(topic,payload,len-llen-3-tl-2, arg);
+                            }
 
                             buffer[0] = MQTTPUBACK;
                             buffer[1] = 2;
@@ -325,7 +383,11 @@ boolean PubSubClient::loop() {
 
                         } else {
                             payload = buffer+llen+3+tl;
-                            callback(topic,payload,len-llen-3-tl);
+                            if (callback) {
+                                callback(topic,payload,len-llen-3-tl);
+                            } else {
+                                callbackWithArg(topic,payload,len-llen-3-tl, arg);
+                            }
                         }
                     }
                 } else if (type == MQTTPINGREQ) {
@@ -570,6 +632,15 @@ PubSubClient& PubSubClient::setServer(const char * domain, uint16_t port) {
 
 PubSubClient& PubSubClient::setCallback(MQTT_CALLBACK_SIGNATURE) {
     this->callback = callback;
+    this->callbackWithArg = NULL;
+    this->arg = NULL;
+    return *this;
+}
+
+PubSubClient& PubSubClient::setCallback(MQTT_CALLBACK_SIGNATURE_WITH_ARG, void* arg) {
+    this->callback = NULL;
+    this->callbackWithArg = callbackWithArg;
+    this->arg = arg;
     return *this;
 }
 

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -76,8 +76,10 @@
 #ifdef ESP8266
 #include <functional>
 #define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, unsigned int)> callback
+#define MQTT_CALLBACK_SIGNATURE_WITH_ARG std::function<void(char*, uint8_t*, unsigned int, void*)> callbackWithArg
 #else
 #define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, unsigned int)
+#define MQTT_CALLBACK_SIGNATURE_WITH_ARG void (*callbackWithArg)(char*, uint8_t*, unsigned int, void*)
 #endif
 
 class PubSubClient {
@@ -88,7 +90,9 @@ private:
    unsigned long lastOutActivity;
    unsigned long lastInActivity;
    bool pingOutstanding;
-   MQTT_CALLBACK_SIGNATURE;
+   MQTT_CALLBACK_SIGNATURE;  
+   MQTT_CALLBACK_SIGNATURE_WITH_ARG; 
+   void* arg;
    uint16_t readPacket(uint8_t*);
    boolean readByte(uint8_t * result);
    boolean readByte(uint8_t * result, uint16_t * index);
@@ -104,21 +108,28 @@ public:
    PubSubClient(Client& client);
    PubSubClient(IPAddress, uint16_t, Client& client);
    PubSubClient(IPAddress, uint16_t, Client& client, Stream&);
-   PubSubClient(IPAddress, uint16_t, MQTT_CALLBACK_SIGNATURE,Client& client);
-   PubSubClient(IPAddress, uint16_t, MQTT_CALLBACK_SIGNATURE,Client& client, Stream&);
+   PubSubClient(IPAddress, uint16_t, MQTT_CALLBACK_SIGNATURE, Client& client);
+   PubSubClient(IPAddress, uint16_t, MQTT_CALLBACK_SIGNATURE, Client& client, Stream&);
+   PubSubClient(IPAddress, uint16_t, MQTT_CALLBACK_SIGNATURE_WITH_ARG, void* arg, Client& client);
+   PubSubClient(IPAddress, uint16_t, MQTT_CALLBACK_SIGNATURE_WITH_ARG, void* arg, Client& client, Stream&);
    PubSubClient(uint8_t *, uint16_t, Client& client);
    PubSubClient(uint8_t *, uint16_t, Client& client, Stream&);
-   PubSubClient(uint8_t *, uint16_t, MQTT_CALLBACK_SIGNATURE,Client& client);
-   PubSubClient(uint8_t *, uint16_t, MQTT_CALLBACK_SIGNATURE,Client& client, Stream&);
+   PubSubClient(uint8_t *, uint16_t, MQTT_CALLBACK_SIGNATURE, Client& client);
+   PubSubClient(uint8_t *, uint16_t, MQTT_CALLBACK_SIGNATURE, Client& client, Stream&);
+   PubSubClient(uint8_t *, uint16_t, MQTT_CALLBACK_SIGNATURE_WITH_ARG, void* arg, Client& client);
+   PubSubClient(uint8_t *, uint16_t, MQTT_CALLBACK_SIGNATURE_WITH_ARG, void* arg, Client& client, Stream&);
    PubSubClient(const char*, uint16_t, Client& client);
    PubSubClient(const char*, uint16_t, Client& client, Stream&);
-   PubSubClient(const char*, uint16_t, MQTT_CALLBACK_SIGNATURE,Client& client);
-   PubSubClient(const char*, uint16_t, MQTT_CALLBACK_SIGNATURE,Client& client, Stream&);
+   PubSubClient(const char*, uint16_t, MQTT_CALLBACK_SIGNATURE, Client& client);
+   PubSubClient(const char*, uint16_t, MQTT_CALLBACK_SIGNATURE, Client& client, Stream&);
+   PubSubClient(const char*, uint16_t, MQTT_CALLBACK_SIGNATURE_WITH_ARG, void* arg, Client& client);
+   PubSubClient(const char*, uint16_t, MQTT_CALLBACK_SIGNATURE_WITH_ARG, void* arg, Client& client, Stream&);
 
    PubSubClient& setServer(IPAddress ip, uint16_t port);
    PubSubClient& setServer(uint8_t * ip, uint16_t port);
    PubSubClient& setServer(const char * domain, uint16_t port);
    PubSubClient& setCallback(MQTT_CALLBACK_SIGNATURE);
+   PubSubClient& setCallback(MQTT_CALLBACK_SIGNATURE_WITH_ARG, void* arg);
    PubSubClient& setClient(Client& client);
    PubSubClient& setStream(Stream& stream);
 

--- a/tests/src/receive_spec.cpp
+++ b/tests/src/receive_spec.cpp
@@ -11,14 +11,16 @@ bool callback_called = false;
 char lastTopic[1024];
 char lastPayload[1024];
 unsigned int lastLength;
-int testParam = 0;
+int testParams[2] = { 0, 0 };
 
 struct TestArg {
-    TestArg(int param):
-        param_(param)
+    TestArg(int param1, int param2):
+        param1_(param1),
+        param2_(param2)
     {}
 
-    int param_;
+    int param1_;
+    int param2_;
 };
 
 void reset_callback() {
@@ -26,7 +28,8 @@ void reset_callback() {
     lastTopic[0] = '\0';
     lastPayload[0] = '\0';
     lastLength = 0;
-    testParam = 0;
+    testParams[0] = 0;
+    testParams[1] = 0;
 }
 
 void callback(char* topic, byte* payload, unsigned int length) {
@@ -41,7 +44,8 @@ void callbackWithArg(char* topic, byte* payload, unsigned int length, void* arg)
     strcpy(lastTopic,topic);
     memcpy(lastPayload,payload,length);
     lastLength = length;
-    testParam = static_cast<TestArg*>(arg)->param_;
+    testParams[0] = static_cast<TestArg*>(arg)->param1_;
+    testParams[1] = static_cast<TestArg*>(arg)->param2_;
 }
 
 int test_receive_callback() {
@@ -85,7 +89,7 @@ int test_receive_callback_with_arg() {
     byte connack[] = { 0x20, 0x02, 0x00, 0x00 };
     shimClient.respond(connack,4);
 
-    TestArg testInstance(1234321);
+    TestArg testInstance(1234321, 3333);
 
     PubSubClient client(server, 1883, callbackWithArg, static_cast<void*>(&testInstance), shimClient);
     int rc = client.connect((char*)"client_test1");
@@ -102,7 +106,8 @@ int test_receive_callback_with_arg() {
     IS_TRUE(strcmp(lastTopic,"topic")==0);
     IS_TRUE(memcmp(lastPayload,"payload",7)==0);
     IS_TRUE(lastLength == 7);
-    IS_TRUE(testParam == 1234321);
+    IS_TRUE(testParams[0] == 1234321);
+    IS_TRUE(testParams[1] == 3333);
 
     IS_FALSE(shimClient.error());
 


### PR DESCRIPTION
Hi,

I've added a possibility to pass an argument into callback function. It may be useful if someone wants to organize subscription handlers into more object-oriented way without unnecessary usage of global variables (e.g. handlers of topic changes encapsulated as separate class).

Usage is similar to arg parameter from pthread_create().

It doesn't break legacy functionality.