### PR TITLE
Implemented half-way qos1 publishing.

### DIFF
--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -23,7 +23,7 @@
 
 // MQTT_MAX_PACKET_SIZE : Maximum packet size
 #ifndef MQTT_MAX_PACKET_SIZE
-#define MQTT_MAX_PACKET_SIZE 128
+#define MQTT_MAX_PACKET_SIZE 1024
 #endif
 
 // MQTT_KEEPALIVE : keepAlive interval in Seconds
@@ -131,6 +131,8 @@ public:
    boolean publish(const char* topic, const char* payload, boolean retained);
    boolean publish(const char* topic, const uint8_t * payload, unsigned int plength);
    boolean publish(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained);
+   boolean publish(const char* topic, const uint8_t* payload, unsigned int plength, boolean retained, 
+		   uint8_t qos, boolean dup, uint8_t messIdMsb, uint8_t messIdLsb);
    boolean publish_P(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained);
    boolean subscribe(const char* topic);
    boolean subscribe(const char* topic, uint8_t qos);


### PR DESCRIPTION
Hi @knolleary,
I know there where other discussions about qos > 0 and you are circumspect about it, but I'm trying my chances :)
As the title said, I have implemented a "half-way" qos1. Half way because the library takes care of "low level qos1 communication", leaving the calling application to take care of messages buffering and PUBACK "decoding".
In this way, I was able to obtain qos1 communication with (in my opinion) minimal changes in the library:
1. Added a new "case" in loop(), to propagates the PUBACK messages to the calling application:
```
  } else if (type == MQTTPUBACK) {
    char topic[] = "puback";
    memmove(buffer, buffer+2, 2);
    payload = buffer;
    callback(topic,payload,2);
  }
```

1. Overloaded the publish method to build and send the qos1 messages:
```
boolean PubSubClient::publish(const char* topic, const uint8_t* payload, unsigned int plength, boolean retained, uint8_t qos, boolean dup, uint8_t messIdMsb, uint8_t messIdLsb) {
```
This pull request is just a proposal, to see if it has any chances. If yes, probably some improvements can be done (better publish() overloading, examples).
If you are unsure about it, I'll supply my own, changed version [with the project I'm using it in](https://github.com/lmmeng/RN).

Thanks for reading it,
Liviu