### PR TITLE
Added reference to PubSubClient object to callback prototype

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -314,7 +314,7 @@ boolean PubSubClient::loop() {
                         if ((buffer[0]&0x06) == MQTTQOS1) {
                             msgId = (buffer[llen+3+tl]<<8)+buffer[llen+3+tl+1];
                             payload = buffer+llen+3+tl+2;
-                            callback(topic,payload,len-llen-3-tl-2);
+                            callback(topic,payload,len-llen-3-tl-2, *this);
 
                             buffer[0] = MQTTPUBACK;
                             buffer[1] = 2;
@@ -325,7 +325,7 @@ boolean PubSubClient::loop() {
 
                         } else {
                             payload = buffer+llen+3+tl;
-                            callback(topic,payload,len-llen-3-tl);
+                            callback(topic,payload,len-llen-3-tl, *this);
                         }
                     }
                 } else if (type == MQTTPINGREQ) {

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -75,9 +75,9 @@
 
 #ifdef ESP8266
 #include <functional>
-#define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, unsigned int)> callback
+#define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, unsigned int, PubSubClient&)> callback
 #else
-#define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, unsigned int)
+#define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, unsigned int, PubSubClient&)
 #endif
 
 class PubSubClient {


### PR DESCRIPTION
As it is, the callback function relies on an external/global instance of
the PubSubClient object if it wants to use the object for instance for
publishing.

It is preferable to be able to pass a reference to the PubSubClient
instance into the callback function when it is called.

To that end the callback signature and the calls to the callback in the
loop method had to be changed.