### PR TITLE
Enable ESP32 to use PubSubClient (make MQTT_CALLBACK_SIGNATURE functional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ boards and shields, including:
  - TI CC3000 WiFi - [library](https://github.com/sparkfun/SFE_CC3000_Library)
  - Intel Galileo/Edison
  - ESP8266
+ - ESP32
 
 The library cannot currently be used with hardware based on the ENC28J60 chip –
 such as the Nanode or the Nuelectronics Ethernet Shield. For those, there is an

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -73,7 +73,7 @@
 #define MQTTQOS1        (1 << 1)
 #define MQTTQOS2        (2 << 1)
 
-#ifdef ESP8266
+#if defined(ESP8266) || defined(ESP32)
 #include <functional>
 #define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, unsigned int)> callback
 #else


### PR DESCRIPTION
#331 

Added functional MQTT_CALLBACK_SIGNATURE to enable binding a object method to the callback handler. 