### PR TITLE
Fix error reporting success status with longer payloads

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -418,7 +418,7 @@ boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsig
 
     lastOutActivity = millis();
 
-    return rc == tlen + 4 + plength;
+    return rc == tlen + 3 + llen + plength;
 }
 
 boolean PubSubClient::write(uint8_t header, uint8_t* buf, uint16_t length) {


### PR DESCRIPTION
Packet length is incorrectly calculated, which results in a failure status being returned when sending longer payloads that were, in fact, sent successfully.
