### PR TITLE
Create new signature to permit cleaner user code

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -376,6 +376,10 @@ boolean PubSubClient::publish(const char* topic, const uint8_t* payload, unsigne
     return false;
 }
 
+boolean PubSubClient::publish_P(const char* topic, const char* payload, boolean retained) {
+    return publish_P(topic, (const uint8_t*)payload, strlen(payload), retained);
+}
+
 boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsigned int plength, boolean retained) {
     uint8_t llen = 0;
     uint8_t digit;

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -131,6 +131,7 @@ public:
    boolean publish(const char* topic, const char* payload, boolean retained);
    boolean publish(const char* topic, const uint8_t * payload, unsigned int plength);
    boolean publish(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained);
+   boolean publish_P(const char* topic, const char* payload, boolean retained);
    boolean publish_P(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained);
    boolean subscribe(const char* topic);
    boolean subscribe(const char* topic, uint8_t qos);


### PR DESCRIPTION
Allows user to write slightly simpler code:

// In the user code...
String json = "some payload";

bool ok = pubSubClient.publish_P("topic", json.c_str(), 0);     // Use new sig
vs.
bool ok = pubSubClient.publish_P("topic", (uint8_t*)json.c_str(), json.length(), 0);     // Use existing sig
