### PR TITLE
Enable PubSubClient for ESP32

### DIFF
--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -76,6 +76,9 @@
 #ifdef ESP8266
 #include <functional>
 #define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, unsigned int)> callback
+#elif defined(ESP32)		// ESP32
+#include <functional>
+#define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, unsigned int)> callback
 #else
 #define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, unsigned int)
 #endif


### PR DESCRIPTION
This simple change will enable PubSubClient to work with ESP32 projects