### PR TITLE
Updated mqtt_esp8266 with connectmqtt()

### DIFF
--- a/examples/mqtt_esp8266/mqtt_esp8266.ino
+++ b/examples/mqtt_esp8266/mqtt_esp8266.ino
@@ -111,7 +111,30 @@ void setup() {
   setup_wifi();
   client.setServer(mqtt_server, 1883);
   client.setCallback(callback);
+  connectmqtt();
+ 
 }
+
+void connectmqtt()
+{
+  String clientId = "ESP8266Client-";
+  clientId += String(random(0xffff), HEX);
+  client.connect(clientId.c_str()));
+  {
+      Serial.println("connected");
+      // Once connected, publish an announcement...
+     
+      // ... and resubscribe
+      client.subscribe("inTopic");
+       client.publish("outTopic", "hello world");
+
+       if (!client.connected()) 
+  {
+    reconnect();
+   }
+  }
+}
+
 
 void loop() {
 


### PR DESCRIPTION
As callback function will not work if Esp8266 connects to broker in a single hit. As client.subscribe() is mentioned in reconnect() function and reconnect will only be called if the connection breaks with MQTT Broker.