### PR TITLE
Buffer overflow fix in writeString(const char*, uint8_t*, uint16_t)

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -529,15 +529,14 @@ void PubSubClient::disconnect() {
 }
 
 uint16_t PubSubClient::writeString(const char* string, uint8_t* buf, uint16_t pos) {
-    const char* idp = string;
-    uint16_t i = 0;
-    pos += 2;
-    while (*idp) {
-        buf[pos++] = *idp++;
-        i++;
+    uint16_t len = strlen(string);
+    uint16_t avail = MQTT_MAX_PACKET_SIZE - pos - 2; // two bytes for length
+    uint16_t size = len > avail ? avail : len;
+    buf[pos++] = (size >> 8);
+    buf[pos++] = (size & 0xFF);
+    for(int i = 0; i < size; i++) {
+      buf[pos++] = string[i];
     }
-    buf[pos-i-2] = (i >> 8);
-    buf[pos-i-1] = (i & 0xFF);
     return pos;
 }
 


### PR DESCRIPTION
There was no check for buffer overflow in writeString() method, so when the string was too long to fit into the buffer, it overwrote arbitrary memory. I encountered this when used with Google Cloud IoT Core which uses JWT as a password. JWT is very long to fit into 128 bytes long buffer (default size). Then the pointer to this->stream got overwritten from NULL to some value and the program crashed in readPacket() method trying to call this->stream->write().
With this fix Google IoT will still not connect because of trimmed password, but at least the program will not crash. MQTT_MAX_PACKET_SIZE must be set to something reasonable big to hold the string.
Maybe returning something like -1 from writeString() should indicate buffer overflow.