### PR TITLE
Update PubSubClient.cpp

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -524,6 +524,7 @@ void PubSubClient::disconnect() {
     buffer[1] = 0;
     _client->write(buffer,2);
     _state = MQTT_DISCONNECTED;
+    _client->flush();
     _client->stop();
     lastInActivity = lastOutActivity = millis();
 }


### PR DESCRIPTION
Make sure all data is flushed to the other end when doing a disconnect(): that way we know for sure that it is there when we disconnect the wifi or maybe even reboot.
This change was made after I noticed that I did not get any mqtt messages. I verified that it indeed solves the problem. Example code on request.