### PR TITLE
Fix spelling in mqtt_esp8266 example

### DIFF
--- a/examples/mqtt_esp8266/mqtt_esp8266.ino
+++ b/examples/mqtt_esp8266/mqtt_esp8266.ino
@@ -74,7 +74,7 @@ void callback(char* topic, byte* payload, unsigned int length) {
   if ((char)payload[0] == '1') {
     digitalWrite(BUILTIN_LED, LOW);   // Turn the LED on (Note that LOW is the voltage level
     // but actually the LED is on; this is because
-    // it is acive low on the ESP-01)
+    // it is active low on the ESP-01)
   } else {
     digitalWrite(BUILTIN_LED, HIGH);  // Turn the LED off by making the voltage HIGH
   }


### PR DESCRIPTION
In comment modify acive to active