### PR TITLE
Added support of CleanSession flag during connect

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -141,7 +141,7 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
 
             uint8_t v;
             if (willTopic) {
-                v = 0x06|(willQos<<3)|(willRetain<<5);
+                v = 0x04|(willQos<<3)|(willRetain<<5);
             } else {
                 v = 0;
             }

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -102,18 +102,18 @@ PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGN
 }
 
 boolean PubSubClient::connect(const char *id) {
-    return connect(id,NULL,NULL,0,0,0,0);
+    return connect(id,NULL,NULL,0,0,0,0,1);
 }
 
 boolean PubSubClient::connect(const char *id, const char *user, const char *pass) {
-    return connect(id,user,pass,0,0,0,0);
+    return connect(id,user,pass,0,0,0,0,1);
 }
 
 boolean PubSubClient::connect(const char *id, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage) {
-    return connect(id,NULL,NULL,willTopic,willQos,willRetain,willMessage);
+    return connect(id,NULL,NULL,willTopic,willQos,willRetain,willMessage,1);
 }
 
-boolean PubSubClient::connect(const char *id, const char *user, const char *pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage) {
+boolean PubSubClient::connect(const char *id, const char *user, const char *pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, boolean cleanSession) {
     if (!connected()) {
         int result = 0;
 
@@ -143,8 +143,11 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
             if (willTopic) {
                 v = 0x06|(willQos<<3)|(willRetain<<5);
             } else {
-                v = 0x02;
+                v = 0;
             }
+
+            if (cleanSession)
+                v = v|0x02;
 
             if(user != NULL) {
                 v = v|0x80;

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -125,7 +125,7 @@ public:
    boolean connect(const char* id);
    boolean connect(const char* id, const char* user, const char* pass);
    boolean connect(const char* id, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage);
-   boolean connect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage);
+   boolean connect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, boolean cleanSession);
    void disconnect();
    boolean publish(const char* topic, const char* payload);
    boolean publish(const char* topic, const char* payload, boolean retained);


### PR DESCRIPTION
Addressing  #281. This change adds support of setting of CleanSession flag in the connect request, based on the connect() function's parameters (additional argument set to true by default for backward compatibility).

Ideally, the standard defines that in case of persistent session, the client must store the QoS 1 and 2 messages in case of sending failures and retry later. However, given that only QoS 1 is currently supported by the library and the fact that the library doesn't re-establish connection by itself, perhaps it's ok to skip implementation of that requirement for now. Also, publish() functions return sending result to the caller which allows implementation of that functionality in the actual program that uses the library (like re-connect attempts)