### PR TITLE
Fix publish() when payload == NULL

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -366,11 +366,11 @@ boolean PubSubClient::loop() {
 }
 
 boolean PubSubClient::publish(const char* topic, const char* payload) {
-    return publish(topic,(const uint8_t*)payload,strlen(payload),false);
+    return publish(topic,(const uint8_t*)payload, payload ? strlen(payload) : 0,false);
 }
 
 boolean PubSubClient::publish(const char* topic, const char* payload, boolean retained) {
-    return publish(topic,(const uint8_t*)payload,strlen(payload),retained);
+    return publish(topic,(const uint8_t*)payload, payload ? strlen(payload) : 0,retained);
 }
 
 boolean PubSubClient::publish(const char* topic, const uint8_t* payload, unsigned int plength) {
@@ -400,7 +400,7 @@ boolean PubSubClient::publish(const char* topic, const uint8_t* payload, unsigne
 }
 
 boolean PubSubClient::publish_P(const char* topic, const char* payload, boolean retained) {
-    return publish_P(topic, (const uint8_t*)payload, strlen(payload), retained);
+    return publish_P(topic, (const uint8_t*)payload, payload ? strlen(payload) : 0, retained);
 }
 
 boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsigned int plength, boolean retained) {


### PR DESCRIPTION
Messages with empty payload are completely valid and are actually useful (e.g., to delete retained value).
This adds a check before calling `strlen()` to prevent crash when using shortcut methods taking `const char*`