### PR TITLE
Allow streaming of large messages

### DIFF
--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -94,7 +94,7 @@ private:
    unsigned long lastInActivity;
    bool pingOutstanding;
    MQTT_CALLBACK_SIGNATURE;
-   uint16_t readPacket(uint8_t*);
+   uint32_t readPacket(uint8_t*);
    boolean readByte(uint8_t * result);
    boolean readByte(uint8_t * result, uint16_t * index);
    boolean write(uint8_t header, uint8_t* buf, uint16_t length);

--- a/tests/src/receive_spec.cpp
+++ b/tests/src/receive_spec.cpp
@@ -190,7 +190,7 @@ int test_drop_invalid_remaining_length_message() {
 
 
 int test_receive_oversized_stream_message() {
-    IT("drops an oversized message");
+    IT("receive an oversized streamed message");
     reset_callback();
 
     Stream stream;
@@ -222,7 +222,7 @@ int test_receive_oversized_stream_message() {
 
     IS_TRUE(callback_called);
     IS_TRUE(strcmp(lastTopic,"topic")==0);
-    IS_TRUE(lastLength == length-9);
+    IS_TRUE(lastLength == 0);
 
     IS_FALSE(stream.error());
     IS_FALSE(shimClient.error());

--- a/tests/src/receive_spec.cpp
+++ b/tests/src/receive_spec.cpp
@@ -222,7 +222,7 @@ int test_receive_oversized_stream_message() {
 
     IS_TRUE(callback_called);
     IS_TRUE(strcmp(lastTopic,"topic")==0);
-    IS_TRUE(lastLength == 0);
+    IS_TRUE(lastLength == MQTT_MAX_PACKET_SIZE);
 
     IS_FALSE(stream.error());
     IS_FALSE(shimClient.error());

--- a/tests/src/receive_spec.cpp
+++ b/tests/src/receive_spec.cpp
@@ -222,7 +222,7 @@ int test_receive_oversized_stream_message() {
 
     IS_TRUE(callback_called);
     IS_TRUE(strcmp(lastTopic,"topic")==0);
-    IS_TRUE(lastLength == MQTT_MAX_PACKET_SIZE);
+    IS_TRUE(lastLength == MQTT_MAX_PACKET_SIZE-9);
 
     IS_FALSE(stream.error());
     IS_FALSE(shimClient.error());


### PR DESCRIPTION
These changes are required to allow for the transmission of large messages through a connected stream. The changes do not have an impact on the class interface and habitual behavior. In particular, it will enable the use of OTA through a stream hooked through the setStream() class method. I've designed such a stream to demonstrate the functionality: https://github.com/turgu1/mqtt_ota_example.git

The change allows readPacket to get very large messages. At the moment, it is limited to 64Kb messages. Transmitting larger messages would allow to send firmware binary updates through the mosquitto_pub command or any other mean as one single message. The change is limited to the readPacket method. The running length variable is transformed to be an int32 instead of an int16.

Guy