### PR TITLE
Support pre-connected Client

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -121,11 +121,17 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
     if (!connected()) {
         int result = 0;
 
-        if (domain != NULL) {
-            result = _client->connect(this->domain, this->port);
+
+        if(_client->connected()) {
+            result = 1;
         } else {
-            result = _client->connect(this->ip, this->port);
+            if (domain != NULL) {
+                result = _client->connect(this->domain, this->port);
+            } else {
+                result = _client->connect(this->ip, this->port);
+            }
         }
+        
         if (result == 1) {
             nextMsgId = 1;
             // Leave room in the buffer for header and variable length field
@@ -610,6 +616,8 @@ boolean PubSubClient::connected() {
                 _client->flush();
                 _client->stop();
             }
+        } else {
+            return this->_state == MQTT_CONNECTED;
         }
     }
     return rc;


### PR DESCRIPTION
I was trying to use this with the `WiFiClientSecure` Client for ESP32 where I need to call its `connect` function manually because it has a non-standard overload to support the TLS/SSL stuff:

`client.connect(DOMAIN, PORT, CA_CERT, CLIENT_CERT, PRIVATE_KEY);`

However, if I use this pre-connected Client with PubSubClient, the latter's connect call will be basically skipped because `pubsub.connected` returns true when the underlying Client is connected, disregarding the it's own internal MQTT state. 

In order to make it work with a pre-connected Client, I did 2 things:
1. in `connected`, double check the internal MQTT state is `MQTT_CONNECTED `, after checking the underlying Client is connected
2. In `connect`, skip the underlying Client's `connect` call if it is already connected.

P.S. It is not needed to call `setServer` if the underlying Client is manually connected.
