### PR TITLE
Fixed ESP8266 example publish as millis() returns unsigned

### DIFF
--- a/examples/mqtt_esp8266/mqtt_esp8266.ino
+++ b/examples/mqtt_esp8266/mqtt_esp8266.ino
@@ -34,7 +34,7 @@ const char* mqtt_server = "broker.mqtt-dashboard.com";
 
 WiFiClient espClient;
 PubSubClient client(espClient);
-long lastMsg = 0;
+unsigned long lastMsg = 0;
 char msg[50];
 int value = 0;
 

--- a/examples/mqtt_esp8266/mqtt_esp8266.ino
+++ b/examples/mqtt_esp8266/mqtt_esp8266.ino
@@ -122,7 +122,7 @@ void loop() {
 
   unsigned long now = millis();
 
-  if (lastMsg < now)
+  if (now < lastMsg)
     lastMsg = 0;
 
   if (now - lastMsg > 2000) {

--- a/examples/mqtt_esp8266/mqtt_esp8266.ino
+++ b/examples/mqtt_esp8266/mqtt_esp8266.ino
@@ -120,7 +120,11 @@ void loop() {
   }
   client.loop();
 
-  long now = millis();
+  unsigned long now = millis();
+
+  if (lastMsg < now)
+    lastMsg = 0;
+
   if (now - lastMsg > 2000) {
     lastMsg = now;
     ++value;


### PR DESCRIPTION
Fixed handling of example code to ensure it also works if millis() reaches the end of its unsigned long range, when it's starting at 0 again.