### PR TITLE
Add non-blocking connect functions and ESP8266 example

### DIFF
--- a/examples/mqtt_esp8266_nonblocking/mqtt_esp8266_nonblocking.ino
+++ b/examples/mqtt_esp8266_nonblocking/mqtt_esp8266_nonblocking.ino
@@ -1,0 +1,152 @@
+/*
+  Basic ESP8266 MQTT example with non-blocking connect
+
+  This sketch demonstrates the capabilities of the pubsub library in combination
+  with the ESP8266 board/library.
+
+  It initiates a non-blocking connection to an MQTT server then:
+  - polls the connection status till it's completed (or times out), letting you perform
+    other non-MQTT tasks in the meantime.
+    
+    Then it:
+  - publishes "hello world" to the topic "outTopic" every two seconds
+  - subscribes to the topic "inTopic", printing out any messages
+    it receives. NB - it assumes the received payloads are strings not binary
+  - If the first character of the topic "inTopic" is an 1, switch ON the ESP Led,
+    else switch it off
+
+  It will reconnect (also in a non-blocking manner) to the server if the connection is lost.
+
+  To install the ESP8266 board, (using Arduino 1.6.4+):
+  - Add the following 3rd party board manager under "File -> Preferences -> Additional Boards Manager URLs":
+       http://arduino.esp8266.com/stable/package_esp8266com_index.json
+  - Open the "Tools -> Board -> Board Manager" and click install for the ESP8266"
+  - Select your ESP8266 in "Tools -> Board"
+
+*/
+
+#include <ESP8266WiFi.h>
+#include <PubSubClient.h>
+
+// Update these with values suitable for your network.
+
+const char* ssid = "..........";
+const char* password = "...........";
+const char* mqtt_server = "iot.eclipse.org";
+
+WiFiClient espClient;
+PubSubClient client(espClient);
+long lastMsg = 0;
+char msg[50];
+int value = 0;
+
+void setup_wifi() {
+
+  delay(10);
+  // We start by connecting to a WiFi network
+  Serial.println();
+  Serial.print("Connecting to ");
+  Serial.println(ssid);
+
+  WiFi.begin(ssid, password);
+
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+
+  randomSeed(micros());
+
+  Serial.println("");
+  Serial.println("WiFi connected");
+  Serial.println("IP address: ");
+  Serial.println(WiFi.localIP());
+}
+
+void callback(char* topic, byte* payload, unsigned int length) {
+  Serial.print("Message arrived [");
+  Serial.print(topic);
+  Serial.print("] ");
+  for (int i = 0; i < length; i++) {
+    Serial.print((char)payload[i]);
+  }
+  Serial.println();
+
+  // Switch on the LED if an 1 was received as first character
+  if ((char)payload[0] == '1') {
+    digitalWrite(BUILTIN_LED, LOW);   // Turn the LED on (Note that LOW is the voltage level
+    // but actually the LED is on; this is because
+    // it is active low on the ESP-01)
+  } else {
+    digitalWrite(BUILTIN_LED, HIGH);  // Turn the LED off by making the voltage HIGH
+  }
+
+}
+
+long lastReconnectAttempt = 0;
+
+void reconnect() {
+  // check that a connection isnt already in progress
+  if (client.state() != MQTT_CONNECT_INPROGRESS) {
+    long now = millis();
+    if (now - lastReconnectAttempt < 5000)
+      return;
+
+    Serial.print("Attempting MQTT connection...");
+    
+    // Create a random client ID
+    String clientId = "ESP8266Client-";
+    clientId += String(random(0xffff), HEX);
+
+    // Attempt to connect
+    lastReconnectAttempt = now;
+    client.beginConnect(clientId.c_str());
+  }
+
+  // check the connect status
+  int ret = client.connectStatus();
+  switch (ret) {
+    case MQTT_CONNECTED:
+      Serial.println("connected");
+      // Once connected, publish an announcement...
+      client.publish("outTopic", "hello world");
+      // ... and resubscribe
+      client.subscribe("inTopic");
+
+      lastReconnectAttempt = 0;
+      break;
+    case MQTT_CONNECT_INPROGRESS:
+      return;
+    default:
+      Serial.print("failed! rc = "); Serial.print(ret);
+      Serial.println(". Trying again in 5 seconds.");
+      break;
+  }
+}
+
+void setup() {
+  pinMode(BUILTIN_LED, OUTPUT);     // Initialize the BUILTIN_LED pin as an output
+  Serial.begin(9600);
+  setup_wifi();
+  client.setServer(mqtt_server, 1883);
+  client.setCallback(callback);
+}
+
+void loop() {
+  if (!client.connected()) {
+    reconnect();
+  }
+  else {
+    client.loop();
+
+    long now = millis();
+    if (now - lastMsg > 2000) {
+      lastMsg = now;
+      ++value;
+      snprintf (msg, 50, "hello world #%ld", value);
+      Serial.print("Publish message: ");
+      Serial.println(msg);
+      client.publish("outTopic", msg);
+    }
+  }
+}

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -95,7 +95,7 @@ private:
    unsigned long lastInActivity;
    bool pingOutstanding;
    MQTT_CALLBACK_SIGNATURE;
-   uint16_t readPacket(uint8_t*);
+   uint32_t readPacket(uint8_t*);
    boolean readByte(uint8_t * result);
    boolean readByte(uint8_t * result, uint16_t * index);
    boolean write(uint8_t header, uint8_t* buf, uint16_t length);

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -42,6 +42,7 @@
 //#define MQTT_MAX_TRANSFER_SIZE 80
 
 // Possible values for client.state()
+#define MQTT_CONNECT_INPROGRESS     -5
 #define MQTT_CONNECTION_TIMEOUT     -4
 #define MQTT_CONNECTION_LOST        -3
 #define MQTT_CONNECT_FAILED         -2
@@ -137,6 +138,20 @@ public:
    boolean connect(const char* id, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage);
    boolean connect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage);
    boolean connect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, boolean cleanSession);
+   
+   /* non-blocking CONNECT functions, they do not wait for CONNACK. 
+      Return true if the TCP connection was made and CONNECT was sent successfully, false otherwise */
+   boolean beginConnect(const char* id);
+   boolean beginConnect(const char* id, const char* user, const char* pass);
+   boolean beginConnect(const char* id, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage);
+   boolean beginConnect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage);
+   boolean beginConnect(const char *id, const char *user, const char *pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, boolean cleanSession);
+   
+   /* call this regularly to check the result of a non-blocking CONNECT.
+      Returns the current state().
+      MQTT_CONNECT_INPROGRESS will be returned until CONNACK is received or a timeout occurs */
+   int connectStatus(void);
+   
    void disconnect();
    boolean publish(const char* topic, const char* payload);
    boolean publish(const char* topic, const char* payload, boolean retained);


### PR DESCRIPTION
First, to make the code easier to grapple with, the nesting levels in `connect()` and `loop()` were reduced with "early returns", without touching any of the actual logic. But I understand this is a matter of style, so it can always be removed if not desired.

Since non-blocking connects are a feature I need and have seen requested here in a few issues, I've created 2 functions for this: `beginConnect()` and `connectStatus()`. These 2 functions are basically copy-pastes of 2 separate parts of the existing `connect()` so that the functionality is still the same.

`connected()` was modified to check the `_state` as well. This was necessary for the new functions to work properly and I don't think this will break anything either, if anything, `connected()` should now be more precise about the connection's status. I tested with the `mqtt_esp8266` example, to be sure.

All other functions remain the same, so that nothing breaks even if the new functions don't work or have any bugs. The new functions do work just fine, as expected though. I tested with the new `mqtt_esp8266_nonblocking` example, breaking the connection and then re-connecting. Here's a screenshot of the serial output:

![Screenshot from 2019-07-16 04-01-44](https://user-images.githubusercontent.com/14207669/61265125-f8045300-a786-11e9-9478-85ab8fc32dcf.png)
