### PR TITLE
Fixed Bad Buffer SHORT MQTT Payload

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -300,7 +300,8 @@ uint16_t PubSubClient::readPacket(uint8_t* lengthLength) {
 }
 
 boolean PubSubClient::loop() {
-    if (connected()) {
+    if (connected()) {   
+   
         unsigned long t = millis();
         if ((t - lastInActivity > MQTT_KEEPALIVE*1000UL) || (t - lastOutActivity > MQTT_KEEPALIVE*1000UL)) {
             if (pingOutstanding) {
@@ -317,6 +318,12 @@ boolean PubSubClient::loop() {
             }
         }
         if (_client->available()) {
+          
+          //clean the buffer		
+          for(int a=0;a<MQTT_MAX_PACKET_SIZE;a++){
+		          buffer[a]=0;
+	            }
+          
             uint8_t llen;
             uint16_t len = readPacket(&llen);
             uint16_t msgId = 0;


### PR DESCRIPTION
I used publish with "1" short value, when i see the subscribed output in serial, we see random chars with the values we sent using MQTT.fx from windows, Android App.
in loop:
added:
 for(int a=0;a<MQTT_MAX_PACKET_SIZE;a++){  buffer[a]=0;   }

The FIX cleans the buffer before receiving. Now, the output of subscription payload is neat.