### PR TITLE
payload should be exactly what we send. Not the buffer.

### DIFF
--- a/examples/mqtt_esp8266/mqtt_esp8266.ino
+++ b/examples/mqtt_esp8266/mqtt_esp8266.ino
@@ -62,6 +62,9 @@ void setup_wifi() {
 }
 
 void callback(char* topic, byte* payload, unsigned int length) {
+ //payload extract
+ payload[length] = '\0';
+ 
   Serial.print("Message arrived [");
   Serial.print(topic);
   Serial.print("] ");


### PR DESCRIPTION
Payload is a buffer, if you don't trim it, it is a chunk that start with your data + other messages leftovers.

so i added in callback to get only the payload:

 //payload extract
 payload[length] = '\0';