### PR TITLE
Soft WDT reset fix on ESP8266

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -194,6 +194,7 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
                     _client->stop();
                     return false;
                 }
+              delay(0);
             }
             uint8_t llen;
             uint16_t len = readPacket(&llen);

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -189,8 +189,7 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
             lastInActivity = lastOutActivity = millis();
 
             while (!_client->available()) {
-                unsigned long t = millis();
-                if (t-lastInActivity >= ((int32_t) MQTT_SOCKET_TIMEOUT*1000UL)) {
+                if (millis()-lastInActivity >= ((int32_t) MQTT_SOCKET_TIMEOUT*1000UL)) {
                     _state = MQTT_CONNECTION_TIMEOUT;
                     _client->stop();
                     return false;


### PR DESCRIPTION
I am getting `Soft WDT reset` while trying to use `connect(ID)`. This zero delay feeds watchdog timer while waiting `_client` answer.
ESP SDK config:
`SDK:2.2.1(cfd48f3)/Core:2.5.2=20502000/lwIP:STABLE-2_1_2_RELEASE/glue:1.1-7-g82abda3/BearSSL:a143020`