### PR TITLE
fix/allow redefining constants (MQTT_MAX_PACKET_SIZE, ...)

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -425,7 +425,7 @@ boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsig
     unsigned int i;
     uint8_t header;
     unsigned int len;
-    int expectedLength;
+    unsigned int expectedLength;
 
     if (!connected()) {
         return false;

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -5,7 +5,9 @@
   http://knolleary.net
 */
 
-#include "PubSubClient.h"
+//#include "PubSubClient.h"
+#if INCLUDE_CPP_FROM_PUBSUBCLIENT_H
+
 #include "Arduino.h"
 
 PubSubClient::PubSubClient() {
@@ -669,3 +671,5 @@ PubSubClient& PubSubClient::setStream(Stream& stream){
 int PubSubClient::state() {
     return this->_state;
 }
+
+#endif // INCLUDE_CPP_FROM_PUBSUBCLIENT_H

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -169,5 +169,11 @@ public:
    int state();
 };
 
+#ifndef INCLUDE_CPP_FROM_PUBSUBCLIENT_H
+#define INCLUDE_CPP_FROM_PUBSUBCLIENT_H 1
+#endif
+#if INCLUDE_CPP_FROM_PUBSUBCLIENT_H
+#include "PubSubClient.cpp"
+#endif
 
 #endif


### PR DESCRIPTION
Redefining constants (like  `MQTT_MAX_TRANSFER_SIZE`) before including `PubSubClient.h` has no effect, because the library is precompiled with default values.
It is even dangerous because the compiled class used in sketch has mismatched valued with the externally (pre)compiled `PubSubClient.cpp` file.

This PR allows to force the compilation of the `.cpp` when including `PubSuClient.h`, using the same constants. There is no breaking change for the general case.


If a complex sketch would include `PubSubClient.h` from two different `.cpp` or `.ino` files, all source files except one would have to define `INCLUDE_CPP_FROM_PUBSUBCLIENT_H` to 0 before including.
Example:

`common.h`:
```cpp
#define MQTT_MAX_TRANSFER_SIZE 512 // application requirements
#include <PubSubClient.h>
```

`sketch-file-1.cpp`:
```cpp
#include "common.h"
```

`sketch-file-2.cpp`:
```cpp
#define INCLUDE_CPP_FROM_PUBSUBCLIENT_H 0
#include "common.h"
```

This is a simple working hack.
The correct way for doing that would be to transform these defines/constants as class members, with the matching getters and setters. This would (breaking) change the API and make the code a little bigger. If the author wishes to, I can update my PR in that way.
