### PR TITLE
ESP32 Enterprise network example - MQTT

### DIFF
--- a/examples/mqtt_esp32_enterprise/mqtt_esp32_enterprise.ino
+++ b/examples/mqtt_esp32_enterprise/mqtt_esp32_enterprise.ino
@@ -1,0 +1,90 @@
+//ESP32 Enteprise network MQTT example - eduroam compatible
+//Author: Martin Chlebovec (martinius96)
+//Web: https://arduino.php5.sk
+
+#include <WiFi.h>
+#include "esp_wpa2.h" //wpa2 library for connections to Enterprise networks
+#include <PubSubClient.h>
+
+
+char EAP_ANONYMOUS_IDENTITY[] = "anonymous@example.com";
+char EAP_IDENTITY[] = "id@example.com";
+char EAP_PASSWORD[] = "EDUROAM_PASSWORD";
+const char* ssid = "eduroam"; // eduroam SSID
+const char* mqtt_server = "mqtt.iotindustries.sk";
+
+WiFiClient espClient;
+PubSubClient client(espClient);
+unsigned long lastMsg = 0;
+char msg[50];
+int counter = 0;
+void callback(char* topic, byte* message, unsigned int length) {
+  Serial.print("Message arrived on topic: ");
+  Serial.print(topic);
+  Serial.print(". Message: ");
+  String messageTemp;
+
+  for (int i = 0; i < length; i++) {
+    Serial.print((char)message[i]);
+    messageTemp += (char)message[i];
+  }
+  Serial.println();
+}
+
+void reconnect() {
+  // Loop until we're reconnected
+  while (!client.connected()) {
+    Serial.print("Attempting MQTT connection...");
+    // Attempt to connect
+    if (client.connect("ESP8266Client")) {
+      Serial.println("connected");
+      // Subscribe
+      // client.subscribe("esp32/output");
+    } else {
+      Serial.print("failed, rc=");
+      Serial.print(client.state());
+      Serial.println(" try again in 5 seconds");
+      // Wait 5 seconds before retrying
+      delay(5000);
+    }
+  }
+}
+void setup() {
+  Serial.begin(115200);
+  esp_wifi_sta_wpa2_ent_set_identity((uint8_t *)EAP_ANONYMOUS_IDENTITY, strlen(EAP_ANONYMOUS_IDENTITY));
+  esp_wifi_sta_wpa2_ent_set_username((uint8_t *)EAP_IDENTITY, strlen(EAP_IDENTITY));
+  esp_wifi_sta_wpa2_ent_set_password((uint8_t *)EAP_PASSWORD, strlen(EAP_PASSWORD));
+  esp_wpa2_config_t config = WPA2_CONFIG_INIT_DEFAULT(); //set config settings to default
+  esp_wifi_sta_wpa2_ent_enable(&config); //set config settings to enable function
+  WiFi.begin(ssid); //connect to wifi network under Enterprise 802.1x
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("WiFi connected");
+  Serial.println("IP address: ");
+  Serial.println(WiFi.localIP());
+  client.setServer(mqtt_server, 1883);
+  client.setCallback(callback);
+}
+void loop() {
+  if (!client.connected()) {
+    reconnect();
+  }
+  if (WiFi.status() != WL_CONNECTED) {
+    WiFi.begin(ssid);
+  }
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  client.loop();
+  if (millis() - lastMsg > 10000) {
+    char counter_array[8];
+    counter  = counter + 1;
+    dtostrf(counter, 1, 2, counter_array);
+    client.publish("tutorial/value", counter_array);
+    client.subscribe("tutorial/value");
+    lastMsg = millis();
+  }
+}


### PR DESCRIPTION
Example for ESP32 boards using PubSubClient library with using WPA/WPA2 Enterprise network for connectivity. Connection to WiFi network such as eduroam, Ziggo and so on.
Supported methods: PEAP + MsCHAPv2, EAP-TTLS + MsCHAPv2.

Working, tested at Technical University in Kosice - Slovakia. Supported versions of Arduino core for ESP32: 1.0.0+
Example have connectivity to public MQTT Broker where it Publish data and Subscribe to them too (as verification of success data transmission to Broker - without retain. 