### PR TITLE
Add flag for enabling debugging of library

### DIFF
--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -85,6 +85,12 @@
 
 #define CHECK_STRING_LENGTH(l,s) if (l+2+strnlen(s, this->bufferSize) > this->bufferSize) {_client->stop();return false;}
 
+#ifdef DEBUG_PUBSUBCLIENT
+#define DEBUG_PSC_PRINTF(fmt, ...)  Serial.printf(("PUBSUBCLIENT:" fmt), ## __VA_ARGS__)
+#else
+#define DEBUG_PSC_PRINTF(...)
+#endif
+
 class PubSubClient : public Print {
 private:
    Client* _client;


### PR DESCRIPTION
I spent a few hours [digging into an issue](
https://stackoverflow.com/questions/63448172/esp8266-failing-to-receive-message-over-mqtt-via-aws-iot-core/63448173) with AWS IoT before I realized that this library was silently dropping a message that was bigger than the buffer. In hindsight it would have been nice to have an easy way to enable verbose debugging output here, so I wanted to propose adding some kind of preprocessor directive to make it easier for others to troubleshoot MQTT issues.