### PR TITLE
Expose Outstanding Actions

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -427,9 +427,6 @@ boolean PubSubClient::loop() {
                     subscribeOutstanding = false;
                 } else if (type == MQTTPUBACK) {
                     publishOutstanding = false;
-                } else {
-                    Serial.print("Unhandled response: ");
-                    Serial.println(type);
                 }
             } else if (!connected()) {
                 // readPacket has closed the connection

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -422,6 +422,8 @@ boolean PubSubClient::loop() {
                     _client->write(this->buffer,2);
                 } else if (type == MQTTPINGRESP) {
                     pingOutstanding = false;
+                } else if (type == MQTTSUBACK) {
+                    subscribeOutstanding = false;
                 }
             } else if (!connected()) {
                 // readPacket has closed the connection
@@ -629,6 +631,7 @@ boolean PubSubClient::subscribe(const char* topic, uint8_t qos) {
         this->buffer[length++] = (nextMsgId & 0xFF);
         length = writeString((char*)topic, this->buffer,length);
         this->buffer[length++] = qos;
+        subscribeOutstanding = true;
         return write(MQTTSUBSCRIBE|MQTTQOS1,this->buffer,length-MQTT_MAX_HEADER_SIZE);
     }
     return false;

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -422,8 +422,14 @@ boolean PubSubClient::loop() {
                     _client->write(this->buffer,2);
                 } else if (type == MQTTPINGRESP) {
                     pingOutstanding = false;
+                    publishOutstanding = false;
                 } else if (type == MQTTSUBACK) {
                     subscribeOutstanding = false;
+                } else if (type == MQTTPUBACK) {
+                    publishOutstanding = false;
+                } else {
+                    Serial.print("Unhandled response: ");
+                    Serial.println(type);
                 }
             } else if (!connected()) {
                 // readPacket has closed the connection
@@ -537,6 +543,7 @@ boolean PubSubClient::beginPublish(const char* topic, unsigned int plength, bool
         size_t hlen = buildHeader(header, this->buffer, plength+length-MQTT_MAX_HEADER_SIZE);
         uint16_t rc = _client->write(this->buffer+(MQTT_MAX_HEADER_SIZE-hlen),length-(MQTT_MAX_HEADER_SIZE-hlen));
         lastOutActivity = millis();
+        publishOutstanding = true;
         return (rc == (length-(MQTT_MAX_HEADER_SIZE-hlen)));
     }
     return false;

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -179,6 +179,7 @@ public:
 
    bool pingOutstanding;
    bool subscribeOutstanding;
+   bool publishOutstanding;
 };
 
 

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -95,7 +95,6 @@ private:
    uint16_t nextMsgId;
    unsigned long lastOutActivity;
    unsigned long lastInActivity;
-   bool pingOutstanding;
    MQTT_CALLBACK_SIGNATURE;
    uint32_t readPacket(uint8_t*);
    boolean readByte(uint8_t * result);
@@ -178,6 +177,8 @@ public:
    boolean connected();
    int state();
 
+   bool pingOutstanding;
+   bool subscribeOutstanding;
 };
 
 


### PR DESCRIPTION
In a recent project, I ran into an issue where my Arduino would routinely lock up without warning and at random times. I was able to finally trace it down to MQTT responses coming during the middle of a publish. This was causing SSLClient to lock up and thus my Arduino to lock up.

The two points where my particular application ran into this issue were with keep alive pings and subscribes. To get around my immediate issue, I just exposed `pingOutstanding` (moved from `private:` to `public:`) and created `subscribeOutstanding`. I then just wait until those are both `false` before trying to publish.

This should probably be generalized a little more with accessor functions rather than using parameters directly, but I just wanted to get something working. I'm willing to work on making this more "productionized" and generic (to include all the ACK callbacks), but wanted to get some guidance from the team about the best path forward.