### PR TITLE
Fix bug in publish_P which will always treat the payload length as 0 when used with PROGMEM

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -472,7 +472,7 @@ boolean PubSubClient::publish(const char* topic, const uint8_t* payload, unsigne
 }
 
 boolean PubSubClient::publish_P(const char* topic, const char* payload, boolean retained) {
-    return publish_P(topic, (const uint8_t*)payload, payload ? strnlen(payload, this->bufferSize) : 0, retained);
+    return publish_P(topic, (const uint8_t*)payload, payload ? strnlen_P(payload, MQTT_MAX_POSSIBLE_PACKET_SIZE) : 0, retained);
 }
 
 boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsigned int plength, boolean retained) {

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -21,6 +21,11 @@
 #define MQTT_VERSION MQTT_VERSION_3_1_1
 #endif
 
+// MQTT_MAX_POSSIBLE_PACKET_SIZE : Maximum packet size defined by MQTT protocol.
+#ifndef MQTT_MAX_POSSIBLE_PACKET_SIZE
+#define MQTT_MAX_POSSIBLE_PACKET_SIZE 268435455 
+#endif
+
 // MQTT_MAX_PACKET_SIZE : Maximum packet size. Override with setBufferSize().
 #ifndef MQTT_MAX_PACKET_SIZE
 #define MQTT_MAX_PACKET_SIZE 256


### PR DESCRIPTION
publish_P used to call strlen to calculate the payload length. This will not work on real PROGMEM memory.
The solution is to call strlen_P which will calculate the string length correctly.