### PR TITLE
-comparison between signed and unsigned integer

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -484,7 +484,7 @@ boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsig
     unsigned int i;
     uint8_t header;
     unsigned int len;
-    int expectedLength;
+    unsigned int expectedLength;
 
     if (!connected()) {
         return false;


### PR DESCRIPTION
sketch\src\PubSubClient\src\PubSubClient.cpp: In member function 'boolean PubSubClient::publish_P(const char*, const uint8_t*, unsigned int, boolean)':

sketch\src\PubSubClient\src\PubSubClient.cpp:523:16: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]

     return (rc == expectedLength);