### PR TITLE
Added QOS2 Support (Asynchronous)

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -631,10 +631,11 @@ boolean PubSubClient::publish_Q1(const char* topic, const uint8_t* payload, unsi
             length=length+2;
             _qos2Packet._qos2Flag[_qos2Packet._qos2CurrentIndex] = MQTTPUBLISH;
             _qos2Packet._qos2SentTime[_qos2Packet._qos2CurrentIndex]=millis();
-            _qos2Packet._qos2CurrentIndex++;
+            
             //debug
-            Serial.print("[PubSubClient]*MQQT qos2 publish MGS id:"); Serial.println(_qos2Packet._qos2MgsID[_qos2Packet._qos2CurrentIndex]); 
-      			
+            Serial.print("[PubSubClient]*MQQT qos2 publish MGS id:"); Serial.println(_qos2Packet._qos2MgsID[_qos2Packet._qos2CurrentIndex]);
+
+            _qos2Packet._qos2CurrentIndex++;      			
       	}
 
                             
@@ -674,6 +675,21 @@ boolean PubSubClient::qos2Emptry(void){
 	}else{
 		return false;
 	}
+}
+
+uint8_t* PubSubClient::qos2BufferAddr(void)
+{
+   	uint16_t tempBufID = 0;
+   	while (tempBufID < MQTT_QOS2_MAX_BUFFER)
+   	{
+   		if(_qos2Packet._qos2Acknowledged[tempBufID] == false)
+   		{
+   			return _qos2Packet._qos2bufferID[tempBufID];
+
+   		}
+   		tempBufID++;
+   	}
+   	return NULL;   	
 }
 
 boolean PubSubClient::publish_P(const char* topic, const char* payload, boolean retained) {

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -475,7 +475,7 @@ boolean PubSubClient::loop() {
                             this->buffer[1] = 2;
                             this->buffer[2] = (msgId >> 8);
                             this->buffer[3] = (msgId & 0xFF);
-                            _client->write(this->buffer,4);3
+                            _client->write(this->buffer,4);
                             lastOutActivity = t;
 
                         } else {

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -332,7 +332,8 @@ boolean PubSubClient::readByte(uint8_t * result) {
 boolean PubSubClient::readByte(uint8_t * result, uint16_t * index){
   uint16_t current_index = *index;
   uint8_t * write_address = &(result[current_index]);
-  if(readByte(write_address)){
+  if(readByte(write_address))
+  {
     *index = current_index + 1;
     return true;
   }
@@ -342,7 +343,7 @@ boolean PubSubClient::readByte(uint8_t * result, uint16_t * index){
 uint32_t PubSubClient::readPacket(uint8_t* lengthLength) {
     uint16_t len = 0;
     if(!readByte(this->buffer, &len)) return 0;
-    bool isPublish = (this->buffer[0]&0xF0) == MQTTPUBLISH;
+    bool isPublish = (this->buffer[0] & 0xF0) == MQTTPUBLISH;
     uint32_t multiplier = 1;
     uint32_t length = 0;
     uint8_t digit = 0;
@@ -436,7 +437,9 @@ boolean PubSubClient::loop() {
         		publish_Q1(_SentQOS1Topic, _qos2Packet._qos2bufferID[qos2ARPacketID], _qos2Packet._qos2Plength[qos2ARPacketID]);
         		_qos2Packet._qos2CurrentIndex = tempPacketID;
         		
-        	}else if(_qos2Packet._qos2Flag[qos2ARPacketID] == MQTTPUBREL){
+        	}
+            else if(_qos2Packet._qos2Flag[qos2ARPacketID] == MQTTPUBREL)
+            {
         		debugmqln("[PubSubClient]-- retrying QOS2 MQTTPUBREL--");
         		qos2Response(MQTTPUBREL | MQTTQOS1 , qos2ARPacketID+1);
         		_qos2Packet._qos2Flag[qos2ARPacketID] = MQTTPUBREL;   

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -608,7 +608,7 @@ boolean PubSubClient::publish_Q1(const char* topic, const uint8_t* payload, unsi
       			_qos2Packet._qos2CurrentIndex = 0;
       		}
 
-      		uint16_t qos2IndexRetry = 0;
+      		qos2IndexRetry = 0;
       		while(_qos2Packet._qos2Acknowledged[_qos2Packet._qos2CurrentIndex] == false)
       		{
       			_qos2Packet._qos2CurrentIndex++;
@@ -617,8 +617,9 @@ boolean PubSubClient::publish_Q1(const char* topic, const uint8_t* payload, unsi
       			_qos2Packet._qos2CurrentIndex = 0;
       			}
       			qos2IndexRetry++;
-      			if(qos2IndexRetry>MQTT_QOS2_MAX_BUFFER){
+      			if(qos2IndexRetry > MQTT_QOS2_MAX_BUFFER){
       				Serial.println("Buffer is full due to unseccessfull transmission.");
+      				return false;
       			}
       		}
 
@@ -665,6 +666,14 @@ boolean PubSubClient::publish_Q1(const char* topic, const uint8_t* payload, unsi
         return write(header,this->buffer,length-5);
     }
     return false;
+}
+
+boolean PubSubClient::qos2Emptry(void){
+	if(qos2IndexRetry <= MQTT_QOS2_MAX_BUFFER){
+		return true;
+	}else{
+		return false;
+	}
 }
 
 boolean PubSubClient::publish_P(const char* topic, const char* payload, boolean retained) {

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -199,6 +199,9 @@ public:
 // Added for QOS2
    boolean qos2Response(uint8_t header, uint16_t qMgsID);
    boolean qos2Emptry(void);
+   uint8_t* qos2BufferAddr(void);
+  
+
    // Start to publish a message.
    // This API:
    //   beginPublish(...)

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -194,12 +194,14 @@ public:
    boolean publish(const char* topic, const char* payload, boolean retained);
    boolean publish(const char* topic, const uint8_t * payload, unsigned int plength);
    boolean publish(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained);
-   boolean publish_Q1(const char* topic, const uint8_t * payload, unsigned int plength);
-   boolean publish_Q1(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained, boolean QOS1_MSG_Repeat);
+   boolean publish_Q1(const char* topic, const uint8_t * payload, unsigned int plength,uint8_t msgId);
+   boolean publish_Q1(const char* topic, const uint8_t* payload, unsigned int plength);
+   boolean publish_Q1(const char* topic, const uint8_t * payload, unsigned int plength,uint8_t mid, boolean retained, boolean QOS1_MSG_Repeat);
    boolean publish_P(const char* topic, const char* payload, boolean retained);
    boolean publish_P(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained);
 // Added for QOS2
    boolean qos2Response(uint8_t header, uint16_t qMgsID);
+   boolean isqos2ack(uint8_t mid);
    uint16_t qos2Empty(void);
    boolean qos2Full(void);
    void qos2ResetBuff(void);

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -33,7 +33,7 @@
 
 // MQTT_SOCKET_TIMEOUT: socket timeout interval in Seconds. Override with setSocketTimeout()
 #ifndef MQTT_SOCKET_TIMEOUT
-#define MQTT_SOCKET_TIMEOUT 120
+#define MQTT_SOCKET_TIMEOUT 10
 #endif
 
 
@@ -46,7 +46,7 @@
 #endif
 
 #ifndef MQTT_QOS2_MAX_BUFFER
-#define MQTT_QOS2_MAX_BUFFER 10
+#define MQTT_QOS2_MAX_BUFFER 120
 #endif
 // MQTT_MAX_TRANSFER_SIZE : limit how much data is passed to the network client
 //  in each write call. Needed for the Arduino Wifi Shield. Leave undefined to
@@ -198,7 +198,9 @@ public:
    boolean publish_P(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained);
 // Added for QOS2
    boolean qos2Response(uint8_t header, uint16_t qMgsID);
-   boolean qos2Emptry(void);
+   uint16_t qos2Empty(void);
+   boolean qos2Full(void);
+   void qos2ResetBuff(void);
    uint8_t* qos2BufferAddr(void);
   
 

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -150,6 +150,7 @@ private:
    uint8_t _QOS_TYPE;
    uint16_t qos2MgsId;
    uint16_t qos2ARPacketID;	// Auto Retry Packet ID
+   uint16_t qos2IndexRetry;  //to check wheather the buffer is full or not
 
 public:
    PubSubClient();
@@ -197,6 +198,7 @@ public:
    boolean publish_P(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained);
 // Added for QOS2
    boolean qos2Response(uint8_t header, uint16_t qMgsID);
+   boolean qos2Emptry(void);
    // Start to publish a message.
    // This API:
    //   beginPublish(...)

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -12,6 +12,8 @@
 #include "Client.h"
 #include "Stream.h"
 
+#define BS_V2
+
 #define MQTT_VERSION_3_1      3
 #define MQTT_VERSION_3_1_1    4
 


### PR DESCRIPTION
I have added Qos2 full support. A buffer of maximum 10 is set by default.  and a function(PubSubClient::qos2Emptry(()) is added to check wheather the buffer is full or not. Buffer will be full if it fails to send all 10 data String. So One have to keep those unconfirmed data for qos2. You can change max qos2 buffer size by changing MQTT_QOS2_MAX_BUFFER value. Working great. 