### PR TITLE
fix "warning: comparison between signed and unsigned integer"

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -484,7 +484,7 @@ boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsig
     unsigned int i;
     uint8_t header;
     unsigned int len;
-    int expectedLength;
+    unsigned int expectedLength;
 
     if (!connected()) {
         return false;


### PR DESCRIPTION
Compiling PubSubClient.cpp with compiler warnings gives:
```
/Users/xxx/Documents/Arduino/libraries/PubSubClient/src/PubSubClient.cpp: In member function 'boolean PubSubClient::publish_P(const char*, const uint8_t*, unsigned int, boolean)':
/Users/hixxx345gr/Documents/Arduino/libraries/PubSubClient/src/PubSubClient.cpp:523:19: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     return (rc == expectedLength);
```

Changing `int expectedLength;` to `unsigned int expectedLength;` is mostly harmless, because `expectedLength = 1 + llen + 2 + tlen + plength;` is greater 0, as there are only values added that are unsigned.