### PR TITLE
Initialize callback to NULL to avoid exception on calling uninitialized callback

### DIFF
--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -96,7 +96,7 @@ private:
    unsigned long lastOutActivity;
    unsigned long lastInActivity;
    bool pingOutstanding;
-   MQTT_CALLBACK_SIGNATURE;
+   MQTT_CALLBACK_SIGNATURE = nullptr;
    uint32_t readPacket(uint8_t*);
    boolean readByte(uint8_t * result);
    boolean readByte(uint8_t * result, uint16_t * index);

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -96,7 +96,7 @@ private:
    unsigned long lastOutActivity;
    unsigned long lastInActivity;
    bool pingOutstanding;
-   MQTT_CALLBACK_SIGNATURE = nullptr;
+   MQTT_CALLBACK_SIGNATURE = NULL;
    uint32_t readPacket(uint8_t*);
    boolean readByte(uint8_t * result);
    boolean readByte(uint8_t * result, uint16_t * index);


### PR DESCRIPTION
Not initializing the callback pointer will cause null pointer exceptions if it is not set manually. If not initialized it will (probably) not be 0 and therefore i.e. PubSubClient.cpp, line 405 will try to call a random address

Some constructors actually set the callback to NULL but most are not.
To make sure that callback will always be set to NULL unless overwritten in a specific constructor or by calling setCallBack() it should be initialized on declaration