### PR TITLE
fix: increase `bytesToWrite` to uint16_t to prevent overflow

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -585,7 +585,7 @@ boolean PubSubClient::write(uint8_t header, uint8_t* buf, uint16_t length) {
 #ifdef MQTT_MAX_TRANSFER_SIZE
     uint8_t* writeBuf = buf+(MQTT_MAX_HEADER_SIZE-hlen);
     uint16_t bytesRemaining = length+hlen;  //Match the length type
-    uint8_t bytesToWrite;
+    uint16_t bytesToWrite;
     boolean result = true;
     while((bytesRemaining > 0) && result) {
         bytesToWrite = (bytesRemaining > MQTT_MAX_TRANSFER_SIZE)?MQTT_MAX_TRANSFER_SIZE:bytesRemaining;


### PR DESCRIPTION
Hello! This PR fixes an integer overflow caused when `MAX_MQTT_TRANSFER_SIZE` is defined as greater than 255 by increasing the `bytesToWrite` variable from 8 to 16 bits. This PR should fix at least one of the issues seen by [this comment](https://github.com/OPEnSLab-OSU/SSLClient/issues/30#issuecomment-802738824).