### PR TITLE
Update PubSubClient.h to fix c++ version related errors

### DIFF
--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -76,7 +76,7 @@
 // Maximum size of fixed header and variable length size header
 #define MQTT_MAX_HEADER_SIZE 5
 
-#if defined(ESP8266) || defined(ESP32)
+#if not (defined(ESP8266) || defined(ESP32))
 #include <functional>
 #define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, unsigned int)> callback
 #else


### PR DESCRIPTION
The code in line 79 raises "Qualified name is not allowed in C++" and "'std' does not have a 'function' member" errors, because of xtensa-lx106-elf-gcc c++ compiler for ESP8266 or ESP32 supported up to C/C++11. Adding "not" in the "if" statement that checks ESPs fixed the problem.