### PR TITLE
remove compiler warning

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -484,7 +484,7 @@ boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsig
     unsigned int i;
     uint8_t header;
     unsigned int len;
-    int expectedLength;
+    unsigned int expectedLength;
 
     if (!connected()) {
         return false;


### PR DESCRIPTION
`expectedLength` should be unsigned like `rc`, there is no negative length to expect: 😁 

```
/Users/xxx/Documents/Arduino/libraries/PubSubClient/src/PubSubClient.cpp: In member function 'boolean PubSubClient::publish_P(const char*, const uint8_t*, unsigned int, boolean)':
/Users/xxx/Documents/Arduino/libraries/PubSubClient/src/PubSubClient.cpp:523:16: warning: comparison of integer expressions of different signedness: 'unsigned int' and 'int' [-Wsign-compare]
  523 |     return (rc == expectedLength);
      |             ~~~^~~~~~~~~~~~~~~~~
```