### PR TITLE
Added will message length to connect method.

### DIFF
--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -147,6 +147,7 @@ public:
    boolean connect(const char* id, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage);
    boolean connect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage);
    boolean connect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, boolean cleanSession);
+   boolean connect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, unsigned int willLength, boolean cleanSession);
    void disconnect();
    boolean publish(const char* topic, const char* payload);
    boolean publish(const char* topic, const char* payload, boolean retained);


### PR DESCRIPTION
First, thanks for this great library!
Current connect method only allows null terminated strings as _willMessage_ payload. 
I needed to send binary data, so I added a _willMessageLenth_ argument. 
If _willMessageLenth_ is zero, willMessage will be copied as a null terminated string. If bigger than zero, _willMessageLenth_ bytes will be copied form _willMessage_.
To keep it simple, buffer length check and copy were implemented inside the connect method. I can create a new check macro and copy function if you prefer.
