### PR TITLE
Implement deep copy.

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -158,6 +158,24 @@ PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGN
     setSocketTimeout(MQTT_SOCKET_TIMEOUT);
 }
 
+PubSubClient::PubSubClient(const PubSubClient& other) :
+        _client(other._client),
+        bufferSize(0),
+        keepAlive(other.keepAlive),
+        socketTimeout(other.socketTimeout),
+        nextMsgId(other.nextMsgId),
+        lastOutActivity(other.lastOutActivity),
+        lastInActivity(other.lastInActivity),
+        pingOutstanding(other.pingOutstanding),
+        ip(other.ip),
+        domain(other.domain),
+        port(other.port),
+        stream(other.stream),
+        _state(other._state) {
+    setBufferSize(other.bufferSize);
+    strncpy((char*) buffer, (const char*) other.buffer, other.bufferSize);
+}
+
 PubSubClient::~PubSubClient() {
   free(this->buffer);
 }

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -127,6 +127,7 @@ public:
    PubSubClient(const char*, uint16_t, Client& client, Stream&);
    PubSubClient(const char*, uint16_t, MQTT_CALLBACK_SIGNATURE,Client& client);
    PubSubClient(const char*, uint16_t, MQTT_CALLBACK_SIGNATURE,Client& client, Stream&);
+   PubSubClient(const PubSubClient& other);
 
    ~PubSubClient();
 


### PR DESCRIPTION
### **Fixed issue**
Shallow copying of the internal buffer when copying the class.

### **Current Behavior**
The default copy constructor perform a shallow copy for the dynamic allocated internal buffer.

### **Proposed solution**
Since the buffer is internal it`s reasonable to provide a copy constructor which perform a deep copy.