### PR TITLE
Added a way to inform the user about possible discarded packets

### DIFF
--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -107,6 +107,8 @@ private:
    // Note: the header is built at the end of the first MQTT_MAX_HEADER_SIZE bytes, so will start
    //       (MQTT_MAX_HEADER_SIZE - <returned size>) bytes into the buffer
    size_t buildHeader(uint8_t header, uint8_t* buf, uint16_t length);
+   // Returns the length in chars needed for a given value with the given argument string to be displayed completly.
+   const uint8_t detect_size(const char* msg, ...) const;
    IPAddress ip;
    const char* domain;
    uint16_t port;


### PR DESCRIPTION
When a packet is bigger than the set `bufferSize`, the `PubSubClient` simply discards them and ignores the possible error, meaning a user is never informed that a packet was dropped.

This can cause confusion tough if a response or message is expected, but nothing is ever received.

Therefore I added a special topic that informs the user that their packet is dropped and how much bigger it was then expected. For that I simply used the callback method as well and called it without any data but with a topic explaining the possible issue.

Would be highly appreciated if this could be merged, so it is easier to detect future issues, when making a mistake and not increasing the size of the `PubSubClient` according to the needs of the system.

The changes have been tested for an ESP32 and both compile and work like expected.

@knolleary Would be nice if this could be merged or another way to inform the user about discarded packets could be found. Perhaps setting an error that could be gotten over a method could work as well.