### PR TITLE
PubSubClient: Add failure test into readByte()

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -286,6 +286,7 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
 
 // reads a byte into result
 boolean PubSubClient::readByte(uint8_t * result) {
+   int rc;
    uint32_t previousMillis = millis();
    while(!_client->available()) {
      yield();
@@ -294,8 +295,12 @@ boolean PubSubClient::readByte(uint8_t * result) {
        return false;
      }
    }
-   *result = _client->read();
-   return true;
+   if(rc >= 0) {
+     rxCount++;
+     *result = rc;
+     return true;
+   }
+   return false;
 }
 
 // reads a byte into result[*index] and increments index


### PR DESCRIPTION
_client->read() returns a signed int which can fail if the underlying stream is implemented as such.

e.g. TinyGsmTCP::read() is implemented to return a -1 on failure

int read() override {
      uint8_t c;
      if (read(&c, 1) == 1) { return c; }
      return -1;
    }

Signed-off-by: Alex J Lennon <ajlennon@dynamicdevices.co.uk>