### PR TITLE
Extend usage of std::function on all the platforms where it's available

### DIFF
--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -76,7 +76,7 @@
 // Maximum size of fixed header and variable length size header
 #define MQTT_MAX_HEADER_SIZE 5
 
-#if defined(ESP8266) || defined(ESP32)
+#if __has_include(<functional>)
 #include <functional>
 #define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, unsigned int)> callback
 #else


### PR DESCRIPTION
At this point in time, C++11 is available on most Arduino platforms and not just on ESP8266 and ESP32.
With this pull request, the ability to supply lambdas (including object methods) to `setCallback()` instead of plain function pointers is extended automatically to all the platforms which provide support for std::function. :)