### PR TITLE
Added getters for IP, Domain, and Port.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ tests/bin
 .piolibdeps
 .clang_complete
 .gcc-flags.json
+cmake-build-*/
+.idea/
+CMakeLists.txt

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -759,6 +759,19 @@ boolean PubSubClient::setBufferSize(uint16_t size) {
 uint16_t PubSubClient::getBufferSize() {
     return this->bufferSize;
 }
+
+__attribute__((unused)) IPAddress PubSubClient::getServerIP() const {
+    return this->ip;
+}
+
+__attribute__((unused)) const char *PubSubClient::getServerDomain() const {
+    return this->domain;
+}
+
+__attribute__((unused)) uint16_t PubSubClient::getServerPort() const {
+    return this->port;
+}
+
 PubSubClient& PubSubClient::setKeepAlive(uint16_t keepAlive) {
     this->keepAlive = keepAlive;
     return *this;

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -141,6 +141,9 @@ public:
 
    boolean setBufferSize(uint16_t size);
    uint16_t getBufferSize();
+   __attribute__((unused)) IPAddress getServerIP() const;
+   __attribute__((unused)) const char * getServerDomain() const;
+   __attribute__((unused)) uint16_t getServerPort() const;
 
    boolean connect(const char* id);
    boolean connect(const char* id, const char* user, const char* pass);


### PR DESCRIPTION
I wanted a way to query the PubSubClient object, for cases where I attempt to connect to multiple different brokers with one PubSubClient object, and for cases where I have multiple PubSubClient objects which are passed around to helper functions.

This has been tested on an ESP32 WROOM with the following block:
```
if( mqttClient.connected() )
{
	Serial.print( "MQTT broker domain: " );
	Serial.println( mqttClient.getServerDomain() );
	Serial.print( "MQTT broker IP: " );
	Serial.println( mqttClient.getServerIP() );
	Serial.print( "MQTT broker port: " );
	Serial.println( mqttClient.getServerPort() );
}
```