### PR TITLE
Fix: Vulnerability in Comparison of different type sizes

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -456,7 +456,7 @@ boolean PubSubClient::publish(const char* topic, const uint8_t* payload, unsigne
         length = writeString(topic,this->buffer,length);
 
         // Add payload
-        uint16_t i;
+        uint32_t i;
         for (i=0;i<plength;i++) {
             this->buffer[length++] = payload[i];
         }


### PR DESCRIPTION
Little change in sizes of for loop iterator "i", from uint16_t to uint32_t, to avoid possible infinite loop, which depends on the value of "plength".
More information in issue: https://github.com/knolleary/pubsubclient/issues/1000 
