### PR TITLE
Quick fix for Arduino R4

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -8,6 +8,10 @@
 #include "PubSubClient.h"
 #include "Arduino.h"
 
+#ifdef ARDUINO_UNOR4_WIFI
+size_t strnlen(const char* b, size_t s) { size_t i; for(i=0; b[i]!=0 && i<s; i++); return i; }
+#endif
+
 PubSubClient::PubSubClient() {
     this->_state = MQTT_DISCONNECTED;
     this->_client = NULL;

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -83,6 +83,9 @@
 #define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, unsigned int)
 #endif
 
+#ifdef ARDUINO_UNOR4_WIFI
+size_t strnlen(const char*, size_t);
+#endif
 #define CHECK_STRING_LENGTH(l,s) if (l+2+strnlen(s, this->bufferSize) > this->bufferSize) {_client->stop();return false;}
 
 class PubSubClient : public Print {


### PR DESCRIPTION
fixed the problem with missing strnlen on Arduino R4 Wifi by adding strnlen into PubSubClient.h and PubSubClient.cpp only for this platform. This is ugly but works. 