### PR TITLE
Change `private` to `protected`

### DIFF
--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -86,7 +86,7 @@
 #define CHECK_STRING_LENGTH(l,s) if (l+2+strnlen(s, this->bufferSize) > this->bufferSize) {_client->stop();return false;}
 
 class PubSubClient : public Print {
-private:
+protected:
    Client* _client;
    uint8_t* buffer;
    uint16_t bufferSize;


### PR DESCRIPTION
While adding some extended functionalities, I was stopped by the `private` directove in the `PubSubClient` class. Would be nice if we could make this `protected` so people don't have to fork the library if they need to implement edge-case behaviour :)