### PR TITLE
change int to unsigned int to avoid compiler warmings in PubSubClient.cpp

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -484,7 +484,7 @@ boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsig
     unsigned int i;
     uint8_t header;
     unsigned int len;
-    int expectedLength;
+    unsigned int expectedLength;
 
     if (!connected()) {
         return false;


### PR DESCRIPTION
Change variable type (int to unsigned int) to avoid compiler warnings.