### PR TITLE
Adding Stream Progress Callback

### DIFF
--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -77,10 +77,12 @@
 #define MQTT_MAX_HEADER_SIZE 5
 
 #if defined(ESP8266) || defined(ESP32)
-#include <functional>
-#define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, unsigned int)> callback
+  #include <functional>
+  #define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, unsigned int)> callback
+  #define MQTT_SP_CALLBACK_SIGNATURE std::function<void(uint32_t, uint32_t)> spCallback
 #else
-#define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, unsigned int)
+  #define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, unsigned int)
+  #define MQTT_SP_CALLBACK_SIGNATURE void (*spCallback)(uint32_t, uint32_t)
 #endif
 
 #define CHECK_STRING_LENGTH(l,s) if (l+2+strnlen(s, this->bufferSize) > this->bufferSize) {_client->stop();return false;}
@@ -97,6 +99,7 @@ private:
    unsigned long lastInActivity;
    bool pingOutstanding;
    MQTT_CALLBACK_SIGNATURE;
+   MQTT_SP_CALLBACK_SIGNATURE;
    uint32_t readPacket(uint8_t*);
    boolean readByte(uint8_t * result);
    boolean readByte(uint8_t * result, uint16_t * index);
@@ -112,6 +115,9 @@ private:
    uint16_t port;
    Stream* stream;
    int _state;
+   uint32_t spProgress; // how often to notify stream progress callback
+   bool downloadingLargeMessage = false;
+
 public:
    PubSubClient();
    PubSubClient(Client& client);
@@ -134,6 +140,7 @@ public:
    PubSubClient& setServer(uint8_t * ip, uint16_t port);
    PubSubClient& setServer(const char * domain, uint16_t port);
    PubSubClient& setCallback(MQTT_CALLBACK_SIGNATURE);
+   PubSubClient& setSPCallback(MQTT_SP_CALLBACK_SIGNATURE, uint32_t n);
    PubSubClient& setClient(Client& client);
    PubSubClient& setStream(Stream& stream);
    PubSubClient& setKeepAlive(uint16_t keepAlive);


### PR DESCRIPTION
Stream progress callback allows you to register a callback with how often you would like an update.

When receiving large payloads streaming to SD card or other stream, you can be notified when the download begins ahead of 
the typical callback, as well as every N bytes downloaded until the download completes, and the normal callback is called.


For instance:

```
void test(uint32_t currentSize, uint32_t totalSize){
  Serial.print(currentSize);
  Serial.print(" of ");
  Serial.println(totalSize);
}
```

```
client.setSPCallback(test,1000);
wfile = SD.open("/FILE", FILE_WRITE);
client.setStream(wfile);
```

```
WiFi: Connecting to test ... (0.867000s) 
WiFi: Connected (1.682000s), ip ---.---.---.---:  
MQTT: Connecting to broker "---.---.---.---" with client name "---------" and username "-------" ... (2.182000s) - ok. (2.207000s) 
MQTT: Subscribed to [test_topic]
0 of 12753
1000 of 12753
2000 of 12753
3000 of 12753
4000 of 12753
5000 of 12753
6000 of 12753
7000 of 12753
8000 of 12753
9000 of 12753
10000 of 12753
11000 of 12753
12000 of 12753
MQTT! Your message may be truncated, please set setMaxPacketSize() to a higher value.
MQTT >> [test_topic] ⸮⸮⸮
got message
```

Also allows for critical tasks to be taken care of in the progress callback that would otherwise be blocked in main loop during download of large payload.