### PR TITLE
Updated mqtt_esp8266.ino to use a better source of random

### DIFF
--- a/examples/mqtt_esp8266/mqtt_esp8266.ino
+++ b/examples/mqtt_esp8266/mqtt_esp8266.ino
@@ -50,7 +50,7 @@ void setup_wifi() {
     Serial.print(".");
   }
 
-  randomSeed(micros());
+  randomSeed(RANDOM_REG32);
 
   Serial.println("");
   Serial.println("WiFi connected");


### PR DESCRIPTION
There's no point to use `micros()` instead of `RANDOM_REG32` on ESP8266, if anything using `micros()` is rather insecure.