### PR TITLE
Fixed max value of "Remaining length" in "Fixed header"

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -554,12 +554,12 @@ size_t PubSubClient::write(const uint8_t *buffer, size_t size) {
     return _client->write(buffer,size);
 }
 
-size_t PubSubClient::buildHeader(uint8_t header, uint8_t* buf, uint16_t length) {
+size_t PubSubClient::buildHeader(uint8_t header, uint8_t* buf, uint32_t length) {
     uint8_t lenBuf[4];
     uint8_t llen = 0;
     uint8_t digit;
     uint8_t pos = 0;
-    uint16_t len = length;
+    uint32_t len = length;
     do {
 
         digit = len  & 127; //digit = len %128
@@ -578,7 +578,7 @@ size_t PubSubClient::buildHeader(uint8_t header, uint8_t* buf, uint16_t length) 
     return llen+1; // Full header size is variable length bit plus the 1-byte fixed header
 }
 
-boolean PubSubClient::write(uint8_t header, uint8_t* buf, uint16_t length) {
+boolean PubSubClient::write(uint8_t header, uint8_t* buf, uint32_t length) {
     uint16_t rc;
     uint8_t hlen = buildHeader(header, buf, length);
 

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -100,13 +100,13 @@ private:
    uint32_t readPacket(uint8_t*);
    boolean readByte(uint8_t * result);
    boolean readByte(uint8_t * result, uint16_t * index);
-   boolean write(uint8_t header, uint8_t* buf, uint16_t length);
+   boolean write(uint8_t header, uint8_t* buf, uint32_t length);
    uint16_t writeString(const char* string, uint8_t* buf, uint16_t pos);
    // Build up the header ready to send
    // Returns the size of the header
    // Note: the header is built at the end of the first MQTT_MAX_HEADER_SIZE bytes, so will start
    //       (MQTT_MAX_HEADER_SIZE - <returned size>) bytes into the buffer
-   size_t buildHeader(uint8_t header, uint8_t* buf, uint16_t length);
+   size_t buildHeader(uint8_t header, uint8_t* buf, uint32_t length);
    IPAddress ip;
    const char* domain;
    uint16_t port;


### PR DESCRIPTION
According to MQTT 3.1 Specification number of bytes in "Control Packet" may be from 1 to 4(up to 256MB). When we try to send data more than 65535(2 bytes) we overflow value in "length" variable. We cant send data more than 65535(2 bytes).