### PR TITLE
Fix request buffer not flushing when sending PINGRESP

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -420,6 +420,7 @@ boolean PubSubClient::loop() {
                     this->buffer[0] = MQTTPINGRESP;
                     this->buffer[1] = 0;
                     _client->write(this->buffer,2);
+                    _client->flush();
                 } else if (type == MQTTPINGRESP) {
                     pingOutstanding = false;
                 }


### PR DESCRIPTION
The request buffer does not flush outcoming requests when responding to PINGs from the broker.